### PR TITLE
feature/DT 7737 add cost allocation tags to batch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "aibs-informatics-aws-utils~=0.0.4",
-    "aibs-informatics-core~=0.0.8",
+    "aibs-informatics-aws-utils~=0.0.8",
+    "aibs-informatics-core~=0.1.0",
     "aws-cdk-lib~=2.96",
     "constructs~=10.0",
     "pydantic~=2.0",

--- a/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/demand_execution.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/demand_execution.py
@@ -243,8 +243,8 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
                     "JobQueue.$": sfn.JsonPath.string_at(f"$.{config_batch_args_path}.job_queue_arn"),
                     "Parameters.$": sfn.JsonPath.object_at(f"$.{config_batch_args_path}.parameters"),
                     "ContainerOverrides.$": sfn.JsonPath.object_at(f"$.{config_batch_args_path}.container_overrides"),
-                    # TODO: should I pass this through the config_batch_args_path?
                     "Tags.$": sfn.JsonPath.object_at("$.request.demand_execution.execution_metadata.tags"),
+                    "PropagateTags": True,
                 },
                 # fmt: on
                 "ResultPath": "$.tasks.batch_submit_task",

--- a/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/demand_execution.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/demand_execution.py
@@ -16,10 +16,12 @@ from aibs_informatics_cdk_lib.common.aws.iam_utils import (
     s3_policy_statement,
     sfn_policy_statement,
 )
+from aibs_informatics_cdk_lib.common.aws.sfn_utils import JsonReferencePath
 from aibs_informatics_cdk_lib.constructs_.base import EnvBaseConstructMixins
 from aibs_informatics_cdk_lib.constructs_.efs.file_system import MountPointConfiguration
 from aibs_informatics_cdk_lib.constructs_.sfn.fragments.base import EnvBaseStateMachineFragment
 from aibs_informatics_cdk_lib.constructs_.sfn.states.common import CommonOperation
+from aibs_informatics_cdk_lib.constructs_.sfn.utils import convert_reference_paths
 
 
 class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixins):
@@ -37,6 +39,7 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
         scratch_mount_point_config: Optional[MountPointConfiguration],
         tmp_mount_point_config: Optional[MountPointConfiguration] = None,
         context_manager_configuration: Optional[Dict[str, Any]] = None,
+        tags: Optional[Dict[str, str]] = None,
     ) -> None:
         super().__init__(scope, id, env_base)
 
@@ -137,6 +140,17 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
             },
         )
 
+        # normalization steps:
+        # - merge build and runtime tags
+
+        norm_parallel = CommonOperation.enclose_chainable(
+            self,
+            "Normalize Demand Execution",
+            self.demand_execution_normalize_tags_chain(tags),
+            input_path="$.request.demand_execution",
+            result_path="$.request.demand_execution",
+        )
+
         prep_scaffolding_task = CommonOperation.enclose_chainable(
             self,
             "Prepare Demand Scaffolding",
@@ -229,6 +243,8 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
                     "JobQueue.$": sfn.JsonPath.string_at(f"$.{config_batch_args_path}.job_queue_arn"),
                     "Parameters.$": sfn.JsonPath.object_at(f"$.{config_batch_args_path}.parameters"),
                     "ContainerOverrides.$": sfn.JsonPath.object_at(f"$.{config_batch_args_path}.container_overrides"),
+                    # TODO: should I pass this through the config_batch_args_path?
+                    "Tags.$": sfn.JsonPath.object_at("$.request.demand_execution.execution_metadata.tags"),
                 },
                 # fmt: on
                 "ResultPath": "$.tasks.batch_submit_task",
@@ -296,6 +312,7 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
         # fmt: off
         definition = (
             start_state
+            .next(norm_parallel)
             .next(prep_scaffolding_task)
             .next(setup_tasks)
             .next(execution_task)
@@ -303,6 +320,41 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
         )
         # fmt: on
         self.definition = definition
+
+    def demand_execution_normalize_tags_chain(
+        self, tags: Optional[Dict[str, str]]
+    ) -> sfn.IChainable:
+        """Merge build and runtime tags.
+
+        Chain Assumptions/Expectations:
+            - input is the demand execution request
+            - output is the demand execution request with merged tags
+
+        If runtime tags are not provided, only build‑time tags are used.
+
+        Args:
+            tags (Optional[Dict[str, str]]): build‑time tags
+        Returns:
+            sfn.IChainable: the state machine fragment
+        """
+
+        static_tags: dict[str, str] = tags or {}  # build‑time default
+        execution_tags_path = JsonReferencePath("execution_metadata.tags")
+
+        static_tags = {
+            f"{k}.$" if isinstance(v, str) and v.startswith("$") else k: v
+            for k, v in static_tags.items()
+        }
+
+        merge_tags_chain = CommonOperation.merge_defaults(
+            self,
+            "Merge Tags",
+            input_path="$",
+            target_path=execution_tags_path.as_reference,
+            defaults=static_tags,
+            check_if_target_present=True,
+        )
+        return merge_tags_chain
 
     @property
     def required_inline_policy_statements(self) -> List[iam.PolicyStatement]:

--- a/src/aibs_informatics_core_app/stacks/demand_execution.py
+++ b/src/aibs_informatics_core_app/stacks/demand_execution.py
@@ -113,7 +113,7 @@ class DemandExecutionStack(EnvBaseStack):
         self._assets = assets
 
         root_mount_point_config = MountPointConfiguration.from_access_point(
-            self.efs_ecosystem.file_system.root_access_point, EFS_MOUNT_PATH
+            self.efs_ecosystem.root_access_point, EFS_MOUNT_PATH
         )
         shared_mount_point_config = MountPointConfiguration.from_access_point(
             self.efs_ecosystem.shared_access_point, "/opt/shared", read_only=True
@@ -158,6 +158,11 @@ class DemandExecutionStack(EnvBaseStack):
             data_sync_state_machine=self.data_sync_state_machine,
             shared_mount_point_config=shared_mount_point_config,
             scratch_mount_point_config=scratch_mount_point_config,
+            tags={
+                "ai:cost-allocation:aibs-informatics-service": "n/a",
+                "ai:cost-allocation:aibs-informatics-workflow-type": "$.execution_type",
+                "ai:cost-allocation:aibs-informatics-workflow-id": "$.execution_id",
+            },
         )
         self.demand_execution_state_machine = demand_execution.to_state_machine("demand-execution")
 


### PR DESCRIPTION
- **Enhance merge_defaults method with additional parameters and improved logic for handling target presence**
- **Add tag normalization in DemandExecutionFragment to merge build and runtime tags**
- **Fix access point reference and add cost allocation tags in DemandExecutionStack**

## What's in this Change?

This change introduces tagging for demand execution jobs. We can now tag the batch jobs of demands. It supports tagging in two ways:
1. statically - when synthesizing the cdk infrastructure code
2. dynamically - when submitting a demand, you can specify it in the new tags field

related to -> https://github.com/AllenInstitute/aibs-informatics-core/pull/27

## Testing
|If tags specified|If tags are not specified|
|---|---|
|<img width="315" alt="image" src="https://github.com/user-attachments/assets/b89bfc33-3449-4376-9d37-85cfb3045796" />|<img width="381" alt="image" src="https://github.com/user-attachments/assets/a905c975-4cf5-4a8a-b304-87c5dbdece8d" />|
|<img width="1415" alt="image" src="https://github.com/user-attachments/assets/dd8e0aa8-970b-4a5c-b0df-139a72dd5f55" />|<img width="1422" alt="image" src="https://github.com/user-attachments/assets/7db917b9-bc80-49c2-b9b4-e73eb97c39a7" />|


<!-- Add any automated/manual test steps that you have run to confirm the changes -->

