### PR TITLE
DT-9926 (1/3): PackageSource model and git ref handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     # AWS CDK dependencies
     "aws-cdk-lib~=2.96",
     "constructs~=10.0",
+    "pydantic~=2.0",
 ]
 
 # For dev dependencies: https://peps.python.org/pep-0735/

--- a/src/aibs_informatics_cdk_lib/common/git.py
+++ b/src/aibs_informatics_cdk_lib/common/git.py
@@ -9,13 +9,48 @@ import os
 import re
 import subprocess
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Literal, cast
 
 from aibs_informatics_core.collections import ValidatedStr
 from aibs_informatics_core.utils.file_operations import remove_path
 
 logger = logging.getLogger(__name__)
+
+GitRefKind = Literal["branch", "tag", "commit"]
+"""The kind of ref a git URL points at.
+
+Branch and tag are interchangeable everywhere we resolve them; commit is not, and is the
+only distinction that changes behaviour (see ``clone_repo`` / ``get_commit_hash_from_url``).
+"""
+
+# The repository portion of a git URL: scheme/host followed by <org>/<name>[.git]
+_REPO_PATTERN = (
+    r"(?P<repo>"
+    r"(?:(?:git|ssh|http(?:s)?)(?::\/\/)(?:[\w\.]+)\/|(?:git@(?:[\w\.]+)):)"
+    r"(?:[\w\.-]+)\/(?:[\w\.-]+)(?:\.git)?"
+    r")"
+)
+# Separators that introduce a ref: `#ref`, `@ref`, and GitHub's `/tree/ref`
+_REF_SEP_PATTERN = r"(?:\#|@|\/tree\/)"
+# A ref name; may contain slashes (e.g. `release/1.0`) but never starts a new URL segment
+_REF_NAME_PATTERN = r"[\w\./-]+"
+# An abbreviated or full commit SHA
+_SHA_PATTERN = r"[a-fA-F0-9]{7,40}"
+
+# Ordered alternation of every ref form we can classify. Fully qualified refs come first so
+# that `refs/heads/x` is not swallowed by the catch-all, and the catch-all comes last.
+_REF_PATTERN = (
+    r"(?:"
+    rf"{_REF_SEP_PATTERN}refs\/heads\/(?P<branch>{_REF_NAME_PATTERN})"
+    rf"|{_REF_SEP_PATTERN}refs\/tags\/(?P<tag>{_REF_NAME_PATTERN})"
+    rf"|\/releases\/tag\/(?P<release_tag>{_REF_NAME_PATTERN})"
+    rf"|\/commit\/(?P<commit_path>{_SHA_PATTERN})"
+    rf"|{_REF_SEP_PATTERN}(?P<commit>{_SHA_PATTERN})"
+    rf"|{_REF_SEP_PATTERN}(?P<ambiguous_ref>{_REF_NAME_PATTERN})"
+    r")?"
+)
 
 
 class GitUrl(ValidatedStr):
@@ -24,17 +59,38 @@ class GitUrl(ValidatedStr):
     Supports various Git URL formats including HTTPS, SSH, and git protocols.
     Can extract repository name and optional ref (branch/tag/commit).
 
+    The ref is classified into a ``GitRefKind`` where the URL says so syntactically
+    (``refs/heads/``, ``refs/tags/``, ``/releases/tag/``, ``/commit/``, or a bare SHA).
+    Anything else -- ``#v1.2.3``, ``/tree/main`` -- is reported as a branch. This is
+    deliberate: ``/tree/`` is GitHub's segment for branches, tags *and* SHAs, so no pattern
+    can tell them apart, and branch vs tag makes no difference to anything downstream
+    (``git ls-remote --branch v1.0.0`` resolves tags just fine). Only commit is special.
+
     Attributes:
         regex_pattern: Compiled regex pattern for URL validation.
+        REF_GROUP_KINDS: Ref capture group name -> the kind of ref it represents.
     """
 
-    regex_pattern: ClassVar[re.Pattern] = re.compile(
-        r"((?:(?:git|ssh|http(?:s)?)(?::\/\/)(?:[\w\.]+)\/|(?:git@(?:[\w\.]+)):)(?:[\w\.-]+)\/(?:[\w\.-]+)(?:\.git)?)(?:(?:\#|@|\/tree\/)([\w\./-]+))?"
-    )
+    regex_pattern: ClassVar[re.Pattern] = re.compile(_REPO_PATTERN + _REF_PATTERN)
+
+    REF_GROUP_KINDS: ClassVar[dict[str, GitRefKind]] = {
+        "branch": "branch",
+        "tag": "tag",
+        "release_tag": "tag",
+        "commit_path": "commit",
+        "commit": "commit",
+        "ambiguous_ref": "branch",
+    }
+
+    @property
+    def match_groups(self) -> Mapping[str, str | None]:
+        """Named capture groups from matching this URL against ``regex_pattern``."""
+        # Validation at construction time guarantees a full match.
+        return cast(re.Match, self.regex_pattern.fullmatch(self)).groupdict()
 
     @property
     def repo_base_url(self) -> str:
-        return f"{self.get_match_groups()[0].removesuffix('.git')}.git"
+        return f"{cast(str, self.match_groups['repo']).removesuffix('.git')}.git"
 
     @property
     def repo_name(self) -> str:
@@ -42,7 +98,28 @@ class GitUrl(ValidatedStr):
 
     @property
     def ref(self) -> str | None:
-        return self.get_match_groups()[-1]
+        """The ref this URL pins, or None if it names no ref.
+
+        Fully qualified refs are reported by their short name, so that ``#refs/tags/v1.0.0``
+        and ``@v1.0.0`` both yield ``v1.0.0`` -- the form git's ``--branch`` accepts.
+        """
+        groups = self.match_groups
+        for group_name in self.REF_GROUP_KINDS:
+            if (value := groups[group_name]) is not None:
+                return value
+        return None
+
+    @property
+    def ref_kind(self) -> GitRefKind | None:
+        """The kind of ref this URL pins, or None if it names no ref.
+
+        Ambiguous refs are reported as ``"branch"``. See the class docstring for why.
+        """
+        groups = self.match_groups
+        for group_name, ref_kind in self.REF_GROUP_KINDS.items():
+            if groups[group_name] is not None:
+                return ref_kind
+        return None
 
 
 def is_repo_url(url: str) -> bool:
@@ -117,26 +194,36 @@ def get_commit_hash_from_url(repo_url: str) -> str:
         repo_url (str): The repository URL.
 
     Returns:
-        The commit hash of the HEAD or specified branch.
+        The commit hash of the HEAD or specified ref.
 
     Raises:
+        ValueError: If the ref does not resolve to any commit on the remote.
         subprocess.CalledProcessError: If git ls-remote fails.
     """
+    url = GitUrl(repo_url)
+    ref = url.ref
+    if ref is not None and url.ref_kind == "commit":
+        # A commit SHA is already the commit hash. `git ls-remote --branch` matches refs
+        # only, so it would exit 0 with no output and leave us with an empty hash.
+        return ref
+    ref = ref or "HEAD"
     try:
-        url = GitUrl(repo_url)
-        branch = url.ref or "HEAD"
         # Use git ls-remote to get the commit hashes of remote heads
         output = (
-            subprocess.check_output(["git", "ls-remote", url.repo_base_url, "--branch", branch])
+            subprocess.check_output(["git", "ls-remote", url.repo_base_url, "--branch", ref])
             .decode("utf-8")
             .strip()
         )
-        # The first part of the output is the commit hash of the HEAD reference
-        commit_hash = output.split("\t")[0]
-        return commit_hash
     except subprocess.CalledProcessError as e:
         logger.error(f"An error occurred: {e}")
         raise e
+    if not output:
+        raise ValueError(
+            f"Could not resolve ref '{ref}' to a commit hash on {url.repo_base_url}. "
+            "The ref does not exist on the remote."
+        )
+    # The first part of the output is the commit hash of the matched reference
+    return output.split("\t")[0]
 
 
 def get_commit_hash_from_local(repo_path: str | Path) -> str:
@@ -254,6 +341,9 @@ def clone_repo(
 
     Returns:
         Path to the cloned repository.
+
+    Raises:
+        subprocess.CalledProcessError: If any of the git commands fail.
     """
     target_path = construct_repo_path(repo_url, target_dir)
 
@@ -278,13 +368,25 @@ def clone_repo(
                 return target_path
         # If the target path exists but the commit hashes do not match, remove the existing path
         remove_path(target_path)
+    git_url = GitUrl(repo_url)
+    ref, ref_kind = git_url.ref, git_url.ref_kind
     try:
         # Clone the repository into the target directory
-        base_url, branch = get_repo_url_components(repo_url)
-        cmd: list[str] = ["git", "clone", base_url, target_path.as_posix(), "--single-branch"]
-        if branch:
-            cmd.extend(["--branch", branch])
+        cmd: list[str] = [
+            "git",
+            "clone",
+            git_url.repo_base_url,
+            target_path.as_posix(),
+            "--single-branch",
+        ]
+        # `--branch` accepts branch and tag names only, so a commit is fetched and checked
+        # out after the fact instead.
+        if ref and ref_kind != "commit":
+            cmd.extend(["--branch", ref])
         subprocess.check_call(cmd)
+        if ref and ref_kind == "commit":
+            subprocess.check_call(["git", "fetch", "origin", ref], cwd=target_path)
+            subprocess.check_call(["git", "checkout", ref], cwd=target_path)
         return target_path
     except subprocess.CalledProcessError as e:
         logger.error(f"An error occurred while trying to clone the repo: {e}")

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
@@ -17,6 +17,11 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset import (
     PYTHON_REGEX_EXCLUDES,
     CodeAsset,
 )
+from aibs_informatics_cdk_lib.constructs_.assets.source import (
+    ContainerImageSource,
+    GitSource,
+    PackageSource,
+)
 
 AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR = "AIBS_INFORMATICS_AWS_LAMBDA_REPO"
 AIBS_INFORMATICS_AWS_LAMBDA_REPO = "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git"
@@ -25,6 +30,25 @@ logger = logging.getLogger(__name__)
 
 
 class AssetsMixin:
+    @classmethod
+    def _normalize_source(
+        cls, source: PackageSource | str | None, default_repo_url: str
+    ) -> PackageSource:
+        """Normalize a source parameter into a PackageSource instance.
+
+        Args:
+            source: A PackageSource, a string (git URL, local path, or image ref), or None.
+            default_repo_url: Default git repo URL to use when source is None.
+
+        Returns:
+            A resolved PackageSource instance.
+        """
+        if source is None:
+            return GitSource(url=default_repo_url)
+        if isinstance(source, str):
+            return PackageSource.from_str(source)
+        return source
+
     @classmethod
     def resolve_repo_path(cls, repo_url: str, repo_path_env_var: str | None) -> Path:
         """Resolves the repo path from the environment or clones the repo from the url
@@ -65,13 +89,19 @@ class AIBSInformaticsCodeAssets(constructs.Construct, AssetsMixin):
         construct_id: str,
         env_base: EnvBase,
         runtime: lambda_.Runtime | None = None,
-        aibs_informatics_aws_lambda_repo: str | None = None,
+        aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
     ) -> None:
         super().__init__(scope, construct_id)
         self.env_base = env_base
         self.runtime = runtime or lambda_.Runtime.PYTHON_3_11
+        self._source = self._normalize_source(
+            aibs_informatics_aws_lambda_repo, AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        )
+        # Backward compatibility
         self.AIBS_INFORMATICS_AWS_LAMBDA_REPO = (
-            aibs_informatics_aws_lambda_repo or AIBS_INFORMATICS_AWS_LAMBDA_REPO
+            self._source.url
+            if isinstance(self._source, GitSource)
+            else AIBS_INFORMATICS_AWS_LAMBDA_REPO
         )
 
     @cached_property
@@ -80,10 +110,18 @@ class AIBSInformaticsCodeAssets(constructs.Construct, AssetsMixin):
 
         Returns:
             The code asset
+
+        Raises:
+            TypeError: If the source is a ContainerImageSource (code assets require a git repo).
         """
+        if isinstance(self._source, ContainerImageSource):
+            raise TypeError(
+                "AIBSInformaticsCodeAssets requires a GitSource. "
+                "ContainerImageSource cannot be used for Lambda code assets."
+            )
 
         repo_path = self.resolve_repo_path(
-            self.AIBS_INFORMATICS_AWS_LAMBDA_REPO, AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR
+            self._source.repo_url_with_ref, AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR
         )
 
         asset_hash = generate_path_hash(
@@ -156,23 +194,35 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
         scope: constructs.Construct,
         construct_id: str,
         env_base: EnvBase,
-        aibs_informatics_aws_lambda_repo: str | None = None,
+        aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
     ) -> None:
         super().__init__(scope, construct_id)
         self.env_base = env_base
+        self._source = self._normalize_source(
+            aibs_informatics_aws_lambda_repo, AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        )
+        # Backward compatibility
         self.AIBS_INFORMATICS_AWS_LAMBDA_REPO = (
-            aibs_informatics_aws_lambda_repo or AIBS_INFORMATICS_AWS_LAMBDA_REPO
+            self._source.url
+            if isinstance(self._source, GitSource)
+            else AIBS_INFORMATICS_AWS_LAMBDA_REPO
         )
 
     @cached_property
-    def AIBS_INFORMATICS_AWS_LAMBDA(self) -> aws_ecr_assets.DockerImageAsset:
-        """Returns a NEW docker asset for aibs-informatics-aws-lambda
+    def AIBS_INFORMATICS_AWS_LAMBDA(self) -> aws_ecr_assets.DockerImageAsset | str:
+        """Returns a docker asset for aibs-informatics-aws-lambda.
+
+        When the source is a GitSource, returns a DockerImageAsset built from the repo.
+        When the source is a ContainerImageSource, returns the image URI string.
 
         Returns:
-            aws_ecr_assets.DockerImageAsset: The docker asset
+            The docker image asset or image URI string.
         """
+        if isinstance(self._source, ContainerImageSource):
+            return self._source.image_uri
+
         repo_path = self.resolve_repo_path(
-            self.AIBS_INFORMATICS_AWS_LAMBDA_REPO, AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR
+            self._source.repo_url_with_ref, AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR
         )
 
         return aws_ecr_assets.DockerImageAsset(
@@ -201,9 +251,21 @@ class AIBSInformaticsAssets(constructs.Construct):
         construct_id: str,
         env_base: EnvBase,
         runtime: lambda_.Runtime | None = None,
+        aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
     ) -> None:
         super().__init__(scope, construct_id)
         self.env_base = env_base
 
-        self.code_assets = AIBSInformaticsCodeAssets(self, "CodeAssets", env_base, runtime=runtime)
-        self.docker_assets = AIBSInformaticsDockerAssets(self, "DockerAssets", env_base)
+        self.code_assets = AIBSInformaticsCodeAssets(
+            self,
+            "CodeAssets",
+            env_base,
+            runtime=runtime,
+            aibs_informatics_aws_lambda_repo=aibs_informatics_aws_lambda_repo,
+        )
+        self.docker_assets = AIBSInformaticsDockerAssets(
+            self,
+            "DockerAssets",
+            env_base,
+            aibs_informatics_aws_lambda_repo=aibs_informatics_aws_lambda_repo,
+        )

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
@@ -64,20 +64,32 @@ class AssetsMixin:
     def _normalize_source(
         cls, source: PackageSource | str | None, default_repo_url: str
     ) -> PackageSource:
-        """Normalize a source parameter into a PackageSource instance.
+        """Normalize a source parameter into a supported PackageSource instance.
 
         Args:
-            source: A PackageSource, a string (git URL, local path, or image ref), or None.
+            source: A GitSource or ContainerImageSource, a string (git URL, local path, or
+                image ref), or None.
             default_repo_url: Default git repo URL to use when source is None.
 
         Returns:
             A resolved PackageSource instance.
+
+        Raises:
+            TypeError: If source is a PackageSource subclass this code path does not
+                support. Callers downstream reach for source-kind-specific properties
+                (e.g. GitSource.repo_url_with_ref), so an unrecognized subclass is
+                rejected here rather than failing later with an AttributeError.
         """
         if source is None:
             return GitSource(url=default_repo_url)
         if isinstance(source, str):
             return PackageSource.from_str(source)
-        return source
+        if isinstance(source, (GitSource, ContainerImageSource)):
+            return source
+        raise TypeError(
+            f"Unsupported package source type: {type(source).__name__}. "
+            "Expected GitSource or ContainerImageSource."
+        )
 
     @classmethod
     def _resolve_deprecated_source(
@@ -210,6 +222,11 @@ class AIBSInformaticsCodeAssets(constructs.Construct, AssetsMixin):
                 "AIBSInformaticsCodeAssets requires a GitSource. "
                 "ContainerImageSource cannot be used for Lambda code assets."
             )
+        if not isinstance(self._source, GitSource):
+            raise TypeError(
+                f"AIBSInformaticsCodeAssets requires a GitSource, got "
+                f"{type(self._source).__name__}."
+            )
 
         repo_path = self.resolve_repo_path(
             self._source.repo_url_with_ref, AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR
@@ -330,9 +347,17 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
 
         Returns:
             The docker image asset or image URI string.
+
+        Raises:
+            TypeError: If the source is neither a ContainerImageSource nor a GitSource.
         """
         if isinstance(self._source, ContainerImageSource):
             return self._source.image_uri
+        if not isinstance(self._source, GitSource):
+            raise TypeError(
+                f"AIBSInformaticsDockerAssets requires a GitSource or ContainerImageSource, "
+                f"got {type(self._source).__name__}."
+            )
 
         repo_path = self.resolve_repo_path(
             self._source.repo_url_with_ref, AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 from pathlib import Path
 
 import aws_cdk as cdk
@@ -26,10 +27,39 @@ from aibs_informatics_cdk_lib.constructs_.assets.source import (
 AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR = "AIBS_INFORMATICS_AWS_LAMBDA_REPO"
 AIBS_INFORMATICS_AWS_LAMBDA_REPO = "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git"
 
+AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM = "aibs_informatics_aws_lambda_source"
+DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM = "aibs_informatics_aws_lambda_repo"
+
 logger = logging.getLogger(__name__)
 
 
+def _deprecated_repo_url(source: PackageSource) -> str | None:
+    """Back-compat shim for the ``AIBS_INFORMATICS_AWS_LAMBDA_REPO`` attribute.
+
+    Args:
+        source: The source the construct was configured with.
+
+    Returns:
+        The repo URL for a GitSource, or None for a ContainerImageSource, which has no
+        repo URL to report.
+    """
+    warnings.warn(
+        "`AIBS_INFORMATICS_AWS_LAMBDA_REPO` is deprecated; use `source` instead. "
+        "It returns None when the source is a ContainerImageSource.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return source.url if isinstance(source, GitSource) else None
+
+
 class AssetsMixin:
+    _source: PackageSource
+
+    @property
+    def source(self) -> PackageSource:
+        """The source these assets are built from."""
+        return self._source
+
     @classmethod
     def _normalize_source(
         cls, source: PackageSource | str | None, default_repo_url: str
@@ -48,6 +78,44 @@ class AssetsMixin:
         if isinstance(source, str):
             return PackageSource.from_str(source)
         return source
+
+    @classmethod
+    def _resolve_deprecated_source(
+        cls,
+        source: PackageSource | str | None,
+        deprecated_source: PackageSource | str | None,
+        param_name: str = AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM,
+        deprecated_param_name: str = DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM,
+    ) -> PackageSource | str | None:
+        """Collapse a source parameter and its deprecated alias into one value.
+
+        Args:
+            source: The value passed under the current parameter name.
+            deprecated_source: The value passed under the deprecated parameter name.
+            param_name: The current parameter name, for messages.
+            deprecated_param_name: The deprecated parameter name, for messages.
+
+        Returns:
+            Whichever of the two was supplied, or None if neither was.
+
+        Raises:
+            ValueError: If both parameters were supplied.
+        """
+        if deprecated_source is None:
+            return source
+        if source is not None:
+            raise ValueError(
+                f"Cannot specify both `{param_name}` and `{deprecated_param_name}`. "
+                f"Use `{param_name}`."
+            )
+        warnings.warn(
+            f"`{deprecated_param_name}` is deprecated; use `{param_name}` instead. "
+            "A source may be a git URL, a local repo path, a container image reference, "
+            "or a PackageSource instance.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return deprecated_source
 
     @classmethod
     def resolve_repo_path(cls, repo_url: str, repo_path_env_var: str | None) -> Path:
@@ -89,20 +157,43 @@ class AIBSInformaticsCodeAssets(constructs.Construct, AssetsMixin):
         construct_id: str,
         env_base: EnvBase,
         runtime: lambda_.Runtime | None = None,
+        aibs_informatics_aws_lambda_source: PackageSource | str | None = None,
         aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
     ) -> None:
+        """Code assets for the aibs-informatics packages.
+
+        Args:
+            scope: The parent construct.
+            construct_id: The construct id.
+            env_base: The environment base.
+            runtime: The lambda runtime to build against. Defaults to Python 3.11.
+            aibs_informatics_aws_lambda_source: The source for the aibs-informatics-aws-lambda
+                asset. May be a git URL, a local repo path, or a PackageSource. Defaults to
+                the public repo.
+            aibs_informatics_aws_lambda_repo: Deprecated alias for
+                ``aibs_informatics_aws_lambda_source``.
+        """
         super().__init__(scope, construct_id)
         self.env_base = env_base
         self.runtime = runtime or lambda_.Runtime.PYTHON_3_11
         self._source = self._normalize_source(
-            aibs_informatics_aws_lambda_repo, AIBS_INFORMATICS_AWS_LAMBDA_REPO
+            self._resolve_deprecated_source(
+                aibs_informatics_aws_lambda_source, aibs_informatics_aws_lambda_repo
+            ),
+            AIBS_INFORMATICS_AWS_LAMBDA_REPO,
         )
-        # Backward compatibility
-        self.AIBS_INFORMATICS_AWS_LAMBDA_REPO = (
-            self._source.url
-            if isinstance(self._source, GitSource)
-            else AIBS_INFORMATICS_AWS_LAMBDA_REPO
-        )
+
+    @property
+    def AIBS_INFORMATICS_AWS_LAMBDA_REPO(self) -> str | None:
+        """The git URL of the aibs-informatics-aws-lambda source repo.
+
+        .. deprecated::
+            Use ``source`` instead.
+
+        Returns:
+            The repo URL for a GitSource, or None for a ContainerImageSource.
+        """
+        return _deprecated_repo_url(self._source)
 
     @cached_property
     def AIBS_INFORMATICS_AWS_LAMBDA(self) -> CodeAsset:
@@ -194,19 +285,41 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
         scope: constructs.Construct,
         construct_id: str,
         env_base: EnvBase,
+        aibs_informatics_aws_lambda_source: PackageSource | str | None = None,
         aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
     ) -> None:
+        """Docker assets for the aibs-informatics packages.
+
+        Args:
+            scope: The parent construct.
+            construct_id: The construct id.
+            env_base: The environment base.
+            aibs_informatics_aws_lambda_source: The source for the aibs-informatics-aws-lambda
+                asset. May be a git URL, a local repo path, a container image reference, or a
+                PackageSource. Defaults to the public repo.
+            aibs_informatics_aws_lambda_repo: Deprecated alias for
+                ``aibs_informatics_aws_lambda_source``.
+        """
         super().__init__(scope, construct_id)
         self.env_base = env_base
         self._source = self._normalize_source(
-            aibs_informatics_aws_lambda_repo, AIBS_INFORMATICS_AWS_LAMBDA_REPO
+            self._resolve_deprecated_source(
+                aibs_informatics_aws_lambda_source, aibs_informatics_aws_lambda_repo
+            ),
+            AIBS_INFORMATICS_AWS_LAMBDA_REPO,
         )
-        # Backward compatibility
-        self.AIBS_INFORMATICS_AWS_LAMBDA_REPO = (
-            self._source.url
-            if isinstance(self._source, GitSource)
-            else AIBS_INFORMATICS_AWS_LAMBDA_REPO
-        )
+
+    @property
+    def AIBS_INFORMATICS_AWS_LAMBDA_REPO(self) -> str | None:
+        """The git URL of the aibs-informatics-aws-lambda source repo.
+
+        .. deprecated::
+            Use ``source`` instead.
+
+        Returns:
+            The repo URL for a GitSource, or None for a ContainerImageSource.
+        """
+        return _deprecated_repo_url(self._source)
 
     @cached_property
     def AIBS_INFORMATICS_AWS_LAMBDA(self) -> aws_ecr_assets.DockerImageAsset | str:
@@ -251,21 +364,62 @@ class AIBSInformaticsAssets(constructs.Construct):
         construct_id: str,
         env_base: EnvBase,
         runtime: lambda_.Runtime | None = None,
+        code_source: GitSource | str | None = None,
+        docker_source: PackageSource | str | None = None,
         aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
     ) -> None:
+        """Code and docker assets for the aibs-informatics packages.
+
+        Code and docker assets take separate sources because they are not interchangeable:
+        a Code Asset requires a checkout to build, so ``code_source`` cannot be a Container
+        Image Source. ``docker_source`` accepts either.
+
+        Args:
+            scope: The parent construct.
+            construct_id: The construct id.
+            env_base: The environment base.
+            runtime: The lambda runtime to build code assets against.
+            code_source: The source for the aibs-informatics-aws-lambda code asset. May be a
+                git URL, a local repo path, or a GitSource. Defaults to the public repo.
+            docker_source: The source for the aibs-informatics-aws-lambda docker asset. May
+                additionally be a container image reference or a ContainerImageSource.
+                Defaults to the public repo.
+            aibs_informatics_aws_lambda_repo: Deprecated. Sets both ``code_source`` and
+                ``docker_source``.
+
+        Raises:
+            ValueError: If the deprecated parameter is combined with either new parameter.
+        """
         super().__init__(scope, construct_id)
         self.env_base = env_base
+
+        resolved_code_source: PackageSource | str | None = code_source
+        resolved_docker_source: PackageSource | str | None = docker_source
+        if aibs_informatics_aws_lambda_repo is not None:
+            if code_source is not None or docker_source is not None:
+                raise ValueError(
+                    "Cannot specify both `aibs_informatics_aws_lambda_repo` and "
+                    "`code_source`/`docker_source`. Use the latter."
+                )
+            warnings.warn(
+                "`aibs_informatics_aws_lambda_repo` is deprecated; use `code_source` and "
+                "`docker_source` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            resolved_code_source = aibs_informatics_aws_lambda_repo
+            resolved_docker_source = aibs_informatics_aws_lambda_repo
 
         self.code_assets = AIBSInformaticsCodeAssets(
             self,
             "CodeAssets",
             env_base,
             runtime=runtime,
-            aibs_informatics_aws_lambda_repo=aibs_informatics_aws_lambda_repo,
+            aibs_informatics_aws_lambda_source=resolved_code_source,
         )
         self.docker_assets = AIBSInformaticsDockerAssets(
             self,
             "DockerAssets",
             env_base,
-            aibs_informatics_aws_lambda_repo=aibs_informatics_aws_lambda_repo,
+            aibs_informatics_aws_lambda_source=resolved_docker_source,
         )

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
@@ -33,55 +33,6 @@ DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM = "aibs_informatics_aws_lamb
 logger = logging.getLogger(__name__)
 
 
-def _deprecated_repo_url(source: PackageSource) -> str | None:
-    """Back-compat shim for the ``AIBS_INFORMATICS_AWS_LAMBDA_REPO`` attribute.
-
-    Args:
-        source: The source the construct was configured with.
-
-    Returns:
-        The repo URL for a GitSource, or None for a ContainerImageSource, which has no
-        repo URL to report.
-    """
-    warnings.warn(
-        "`AIBS_INFORMATICS_AWS_LAMBDA_REPO` is deprecated; use `source` instead. "
-        "It returns None when the source is a ContainerImageSource.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    return source.url if isinstance(source, GitSource) else None
-
-
-def _pop_deprecated_source_kwarg(
-    kwargs: dict[str, PackageSource | str | None],
-    owner: str,
-    deprecated_param_name: str = DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM,
-) -> PackageSource | str | None:
-    """Pop the deprecated source alias out of ``**kwargs`` and reject anything else.
-
-    The alias is absorbed into ``**kwargs`` rather than named as a parameter so it stays
-    out of the public signature and the generated API reference.
-
-    Args:
-        kwargs: The keyword arguments the constructor collected.
-        owner: The class name, for the error message.
-        deprecated_param_name: The deprecated keyword to accept.
-
-    Returns:
-        The value passed under the deprecated keyword, or None.
-
-    Raises:
-        TypeError: For any other keyword. Without this, ``**kwargs`` would silently
-            swallow a near miss like ``aibs_informatics_aws_lambda_rep=...`` and leave
-            the construct on its default source while the caller believed it was pinned.
-    """
-    deprecated_source = kwargs.pop(deprecated_param_name, None)
-    if kwargs:
-        unexpected = ", ".join(f"'{name}'" for name in sorted(kwargs))
-        raise TypeError(f"{owner}.__init__() got an unexpected keyword argument {unexpected}")
-    return deprecated_source
-
-
 class AssetsMixin:
     _source: PackageSource
 
@@ -90,25 +41,30 @@ class AssetsMixin:
         """The source these assets are built from."""
         return self._source
 
+    @property
+    def AIBS_INFORMATICS_AWS_LAMBDA_REPO(self) -> str | None:
+        """The git URL of the source repo, or None for a ContainerImageSource.
+
+        .. deprecated::
+            Use ``source`` instead.
+        """
+        warnings.warn(
+            "`AIBS_INFORMATICS_AWS_LAMBDA_REPO` is deprecated; use `source` instead. "
+            "It returns None when the source is a ContainerImageSource.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._source.url if isinstance(self._source, GitSource) else None
+
     @classmethod
     def _normalize_source(
         cls, source: PackageSource | str | None, default_repo_url: str
     ) -> PackageSource:
         """Normalize a source parameter into a supported PackageSource instance.
 
-        Args:
-            source: A GitSource or ContainerImageSource, a string (git URL, local path, or
-                image ref), or None.
-            default_repo_url: Default git repo URL to use when source is None.
-
-        Returns:
-            A resolved PackageSource instance.
-
-        Raises:
-            TypeError: If source is a PackageSource subclass this code path does not
-                support. Callers downstream reach for source-kind-specific properties
-                (e.g. GitSource.repo_url_with_ref), so an unrecognized subclass is
-                rejected here rather than failing later with an AttributeError.
+        An unsupported PackageSource subclass is rejected here because downstream callers
+        reach for source-kind-specific properties (e.g. GitSource.repo_url_with_ref) and
+        would otherwise fail later with an AttributeError.
         """
         if source is None:
             return GitSource(url=default_repo_url)
@@ -125,35 +81,39 @@ class AssetsMixin:
     def _resolve_deprecated_source(
         cls,
         source: PackageSource | str | None,
-        deprecated_source: PackageSource | str | None,
-        param_name: str = AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM,
-        deprecated_param_name: str = DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM,
+        kwargs: dict[str, PackageSource | str | None],
     ) -> PackageSource | str | None:
-        """Collapse a source parameter and its deprecated alias into one value.
+        """Collapse the source parameter and its deprecated alias, consuming ``kwargs``.
 
-        Args:
-            source: The value passed under the current parameter name.
-            deprecated_source: The value passed under the deprecated parameter name.
-            param_name: The current parameter name, for messages.
-            deprecated_param_name: The deprecated parameter name, for messages.
+        The alias lives in ``**kwargs`` rather than in the signature so it stays out of the
+        public API and the generated reference. That means this must raise on any other
+        keyword: a typo like ``aibs_informatics_aws_lambda_rep=...`` would otherwise be
+        swallowed, leaving the construct on its default source while the caller believed
+        they had pinned a version.
 
-        Returns:
-            Whichever of the two was supplied, or None if neither was.
-
-        Raises:
-            ValueError: If both parameters were supplied.
+        ``stacklevel=3`` targets a subclass forwarding the alias through
+        ``super().__init__()``, which is how every downstream consumer passes it. A direct
+        call lands on jsii's metaclass instead; no single value serves both, and
+        ``skip_file_prefixes`` needs Python 3.12.
         """
+        deprecated_source = kwargs.pop(DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM, None)
+        if kwargs:
+            unexpected = ", ".join(f"'{name}'" for name in sorted(kwargs))
+            raise TypeError(
+                f"{cls.__name__}.__init__() got an unexpected keyword argument {unexpected}"
+            )
         if deprecated_source is None:
             return source
         if source is not None:
             raise ValueError(
-                f"Cannot specify both `{param_name}` and `{deprecated_param_name}`. "
-                f"Use `{param_name}`."
+                f"Cannot specify both `{AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM}` and "
+                f"`{DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM}`. "
+                f"Use `{AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM}`."
             )
         warnings.warn(
-            f"`{deprecated_param_name}` is deprecated; use `{param_name}` instead. "
-            "A source may be a git URL, a local repo path, a container image reference, "
-            "or a PackageSource instance.",
+            f"`{DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM}` is deprecated; use "
+            f"`{AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM}` instead. A source may be a git URL, "
+            "a local repo path, a container image reference, or a PackageSource instance.",
             DeprecationWarning,
             stacklevel=3,
         )
@@ -219,24 +179,9 @@ class AIBSInformaticsCodeAssets(constructs.Construct, AssetsMixin):
         self.env_base = env_base
         self.runtime = runtime or lambda_.Runtime.PYTHON_3_11
         self._source = self._normalize_source(
-            self._resolve_deprecated_source(
-                aibs_informatics_aws_lambda_source,
-                _pop_deprecated_source_kwarg(kwargs, type(self).__name__),
-            ),
+            self._resolve_deprecated_source(aibs_informatics_aws_lambda_source, kwargs),
             AIBS_INFORMATICS_AWS_LAMBDA_REPO,
         )
-
-    @property
-    def AIBS_INFORMATICS_AWS_LAMBDA_REPO(self) -> str | None:
-        """The git URL of the aibs-informatics-aws-lambda source repo.
-
-        .. deprecated::
-            Use ``source`` instead.
-
-        Returns:
-            The repo URL for a GitSource, or None for a ContainerImageSource.
-        """
-        return _deprecated_repo_url(self._source)
 
     @cached_property
     def AIBS_INFORMATICS_AWS_LAMBDA(self) -> CodeAsset:
@@ -351,24 +296,9 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
         super().__init__(scope, construct_id)
         self.env_base = env_base
         self._source = self._normalize_source(
-            self._resolve_deprecated_source(
-                aibs_informatics_aws_lambda_source,
-                _pop_deprecated_source_kwarg(kwargs, type(self).__name__),
-            ),
+            self._resolve_deprecated_source(aibs_informatics_aws_lambda_source, kwargs),
             AIBS_INFORMATICS_AWS_LAMBDA_REPO,
         )
-
-    @property
-    def AIBS_INFORMATICS_AWS_LAMBDA_REPO(self) -> str | None:
-        """The git URL of the aibs-informatics-aws-lambda source repo.
-
-        .. deprecated::
-            Use ``source`` instead.
-
-        Returns:
-            The repo URL for a GitSource, or None for a ContainerImageSource.
-        """
-        return _deprecated_repo_url(self._source)
 
     @cached_property
     def AIBS_INFORMATICS_AWS_LAMBDA(self) -> aws_ecr_assets.DockerImageAsset | str:

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
@@ -52,6 +52,36 @@ def _deprecated_repo_url(source: PackageSource) -> str | None:
     return source.url if isinstance(source, GitSource) else None
 
 
+def _pop_deprecated_source_kwarg(
+    kwargs: dict[str, PackageSource | str | None],
+    owner: str,
+    deprecated_param_name: str = DEPRECATED_AIBS_INFORMATICS_AWS_LAMBDA_SOURCE_PARAM,
+) -> PackageSource | str | None:
+    """Pop the deprecated source alias out of ``**kwargs`` and reject anything else.
+
+    The alias is absorbed into ``**kwargs`` rather than named as a parameter so it stays
+    out of the public signature and the generated API reference.
+
+    Args:
+        kwargs: The keyword arguments the constructor collected.
+        owner: The class name, for the error message.
+        deprecated_param_name: The deprecated keyword to accept.
+
+    Returns:
+        The value passed under the deprecated keyword, or None.
+
+    Raises:
+        TypeError: For any other keyword. Without this, ``**kwargs`` would silently
+            swallow a near miss like ``aibs_informatics_aws_lambda_rep=...`` and leave
+            the construct on its default source while the caller believed it was pinned.
+    """
+    deprecated_source = kwargs.pop(deprecated_param_name, None)
+    if kwargs:
+        unexpected = ", ".join(f"'{name}'" for name in sorted(kwargs))
+        raise TypeError(f"{owner}.__init__() got an unexpected keyword argument {unexpected}")
+    return deprecated_source
+
+
 class AssetsMixin:
     _source: PackageSource
 
@@ -170,7 +200,7 @@ class AIBSInformaticsCodeAssets(constructs.Construct, AssetsMixin):
         env_base: EnvBase,
         runtime: lambda_.Runtime | None = None,
         aibs_informatics_aws_lambda_source: PackageSource | str | None = None,
-        aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
+        **kwargs: PackageSource | str | None,
     ) -> None:
         """Code assets for the aibs-informatics packages.
 
@@ -182,15 +212,16 @@ class AIBSInformaticsCodeAssets(constructs.Construct, AssetsMixin):
             aibs_informatics_aws_lambda_source: The source for the aibs-informatics-aws-lambda
                 asset. May be a git URL, a local repo path, or a PackageSource. Defaults to
                 the public repo.
-            aibs_informatics_aws_lambda_repo: Deprecated alias for
-                ``aibs_informatics_aws_lambda_source``.
+            **kwargs: Accepts only the deprecated ``aibs_informatics_aws_lambda_repo`` alias
+                for ``aibs_informatics_aws_lambda_source``. Any other keyword is a TypeError.
         """
         super().__init__(scope, construct_id)
         self.env_base = env_base
         self.runtime = runtime or lambda_.Runtime.PYTHON_3_11
         self._source = self._normalize_source(
             self._resolve_deprecated_source(
-                aibs_informatics_aws_lambda_source, aibs_informatics_aws_lambda_repo
+                aibs_informatics_aws_lambda_source,
+                _pop_deprecated_source_kwarg(kwargs, type(self).__name__),
             ),
             AIBS_INFORMATICS_AWS_LAMBDA_REPO,
         )
@@ -303,7 +334,7 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
         construct_id: str,
         env_base: EnvBase,
         aibs_informatics_aws_lambda_source: PackageSource | str | None = None,
-        aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
+        **kwargs: PackageSource | str | None,
     ) -> None:
         """Docker assets for the aibs-informatics packages.
 
@@ -314,14 +345,15 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
             aibs_informatics_aws_lambda_source: The source for the aibs-informatics-aws-lambda
                 asset. May be a git URL, a local repo path, a container image reference, or a
                 PackageSource. Defaults to the public repo.
-            aibs_informatics_aws_lambda_repo: Deprecated alias for
-                ``aibs_informatics_aws_lambda_source``.
+            **kwargs: Accepts only the deprecated ``aibs_informatics_aws_lambda_repo`` alias
+                for ``aibs_informatics_aws_lambda_source``. Any other keyword is a TypeError.
         """
         super().__init__(scope, construct_id)
         self.env_base = env_base
         self._source = self._normalize_source(
             self._resolve_deprecated_source(
-                aibs_informatics_aws_lambda_source, aibs_informatics_aws_lambda_repo
+                aibs_informatics_aws_lambda_source,
+                _pop_deprecated_source_kwarg(kwargs, type(self).__name__),
             ),
             AIBS_INFORMATICS_AWS_LAMBDA_REPO,
         )
@@ -389,62 +421,40 @@ class AIBSInformaticsAssets(constructs.Construct):
         construct_id: str,
         env_base: EnvBase,
         runtime: lambda_.Runtime | None = None,
-        code_source: GitSource | str | None = None,
-        docker_source: PackageSource | str | None = None,
-        aibs_informatics_aws_lambda_repo: PackageSource | str | None = None,
+        aibs_informatics_aws_lambda_code_source: GitSource | str | None = None,
+        aibs_informatics_aws_lambda_docker_source: PackageSource | str | None = None,
     ) -> None:
         """Code and docker assets for the aibs-informatics packages.
 
-        Code and docker assets take separate sources because they are not interchangeable:
-        a Code Asset requires a checkout to build, so ``code_source`` cannot be a Container
-        Image Source. ``docker_source`` accepts either.
+        The code and docker assets take separate sources because they are not
+        interchangeable: a Code Asset requires a checkout to build, so its source cannot be
+        a Container Image Source. The docker asset accepts either.
 
         Args:
             scope: The parent construct.
             construct_id: The construct id.
             env_base: The environment base.
             runtime: The lambda runtime to build code assets against.
-            code_source: The source for the aibs-informatics-aws-lambda code asset. May be a
-                git URL, a local repo path, or a GitSource. Defaults to the public repo.
-            docker_source: The source for the aibs-informatics-aws-lambda docker asset. May
-                additionally be a container image reference or a ContainerImageSource.
-                Defaults to the public repo.
-            aibs_informatics_aws_lambda_repo: Deprecated. Sets both ``code_source`` and
-                ``docker_source``.
-
-        Raises:
-            ValueError: If the deprecated parameter is combined with either new parameter.
+            aibs_informatics_aws_lambda_code_source: The source for the
+                aibs-informatics-aws-lambda code asset. May be a git URL, a local repo path,
+                or a GitSource. Defaults to the public repo.
+            aibs_informatics_aws_lambda_docker_source: The source for the
+                aibs-informatics-aws-lambda docker asset. May additionally be a container
+                image reference or a ContainerImageSource. Defaults to the public repo.
         """
         super().__init__(scope, construct_id)
         self.env_base = env_base
-
-        resolved_code_source: PackageSource | str | None = code_source
-        resolved_docker_source: PackageSource | str | None = docker_source
-        if aibs_informatics_aws_lambda_repo is not None:
-            if code_source is not None or docker_source is not None:
-                raise ValueError(
-                    "Cannot specify both `aibs_informatics_aws_lambda_repo` and "
-                    "`code_source`/`docker_source`. Use the latter."
-                )
-            warnings.warn(
-                "`aibs_informatics_aws_lambda_repo` is deprecated; use `code_source` and "
-                "`docker_source` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            resolved_code_source = aibs_informatics_aws_lambda_repo
-            resolved_docker_source = aibs_informatics_aws_lambda_repo
 
         self.code_assets = AIBSInformaticsCodeAssets(
             self,
             "CodeAssets",
             env_base,
             runtime=runtime,
-            aibs_informatics_aws_lambda_source=resolved_code_source,
+            aibs_informatics_aws_lambda_source=aibs_informatics_aws_lambda_code_source,
         )
         self.docker_assets = AIBSInformaticsDockerAssets(
             self,
             "DockerAssets",
             env_base,
-            aibs_informatics_aws_lambda_source=resolved_docker_source,
+            aibs_informatics_aws_lambda_source=aibs_informatics_aws_lambda_docker_source,
         )

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/source.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/source.py
@@ -1,0 +1,119 @@
+"""Package source models for resolving code and container image assets.
+
+This module provides Pydantic models for referencing specific versions of a package,
+whether from a Git repository or a container image registry.
+"""
+
+import re
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Discriminator
+
+from aibs_informatics_cdk_lib.common.git import GitUrl, is_local_repo, is_repo_url
+
+# Matches container image references: registry.tld/path[:tag][@sha256:digest]
+_CONTAINER_IMAGE_RE = re.compile(
+    r"^(?P<image>[\w.\-]+\.[\w.\-]+(?:/[\w.\-]+)+)"
+    r"(?::(?P<tag>[\w][\w.\-]*))?(?:@(?P<digest>sha256:[a-fA-F0-9]+))?$"
+)
+
+
+class PackageSource(BaseModel):
+    """Base reference to a specific version of a package."""
+
+    source_type: str
+
+    def version_id(self) -> str:
+        """Return a deterministic identifier for asset hashing and cache keys."""
+        raise NotImplementedError
+
+    @classmethod
+    def from_str(cls, value: str) -> "PackageSource":
+        """Parse a string into the appropriate source type.
+
+        Handles:
+          - Git SSH/HTTPS URLs:  git@github.com:org/repo.git
+          - Git URLs with ref:   git@github.com:org/repo.git#v1.2.3
+          - Local repo paths:    /home/user/workspace/my-repo
+          - Container images:    ghcr.io/org/repo:tag
+          - Container digests:   ghcr.io/org/repo@sha256:abc123
+
+        Args:
+            value: The string to parse.
+
+        Returns:
+            A GitSource or ContainerImageSource instance.
+
+        Raises:
+            ValueError: If the string cannot be parsed as any known source type.
+        """
+        if is_repo_url(value):
+            git_url = GitUrl(value)
+            return GitSource(url=git_url.repo_base_url, branch=git_url.ref)
+
+        if is_local_repo(value):
+            return GitSource(url=value)
+
+        match = _CONTAINER_IMAGE_RE.match(value)
+        if match:
+            return ContainerImageSource(
+                image=match.group("image"),
+                tag=match.group("tag") or "latest",
+                digest=match.group("digest"),
+            )
+
+        raise ValueError(
+            f"Cannot parse '{value}' as a package source. "
+            "Expected a git URL, local repo path, or container image reference."
+        )
+
+
+class GitSource(PackageSource):
+    """Reference to a git repository, optionally pinned to a specific ref."""
+
+    source_type: Literal["git"] = "git"
+    url: str
+    branch: str | None = None
+    commit: str | None = None
+    tag: str | None = None
+
+    def version_id(self) -> str:
+        return self.commit or self.tag or self.branch or "HEAD"
+
+    @property
+    def repo_url_with_ref(self) -> str:
+        """Reconstruct the URL with ref appended (e.g. repo.git#v1.2.3).
+
+        Compatible with the existing clone_repo / resolve_repo_path functions
+        which parse the #ref fragment.
+        """
+        ref = self.commit or self.tag or self.branch
+        if ref:
+            return f"{self.url}#{ref}"
+        return self.url
+
+
+class ContainerImageSource(PackageSource):
+    """Reference to a pre-built container image in a registry."""
+
+    source_type: Literal["container"] = "container"
+    image: str
+    tag: str = "latest"
+    digest: str | None = None
+
+    def version_id(self) -> str:
+        return self.digest or self.tag
+
+    @property
+    def image_uri(self) -> str:
+        """Full image URI suitable for ECR/Batch/ECS consumption."""
+        if self.digest:
+            return f"{self.image}@{self.digest}"
+        return f"{self.image}:{self.tag}"
+
+
+PackageSourceType = Annotated[
+    GitSource | ContainerImageSource,
+    Discriminator("source_type"),
+]
+"""Discriminated union type for use in other Pydantic models."""

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/source.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/source.py
@@ -24,7 +24,14 @@ class PackageSource(BaseModel):
     source_type: str
 
     def version_id(self) -> str:
-        """Return a deterministic identifier for asset hashing and cache keys."""
+        """The deterministic identifier for the exact version this source names.
+
+        Returns:
+            An identifier that is stable for a given version of the source.
+
+        Raises:
+            NotImplementedError: Always; subclasses must implement this.
+        """
         raise NotImplementedError
 
     @classmethod
@@ -38,6 +45,9 @@ class PackageSource(BaseModel):
           - Container images:    ghcr.io/org/repo:tag
           - Container digests:   ghcr.io/org/repo@sha256:abc123
 
+        A git ref lands on the GitSource field matching its kind. Refs the URL does not
+        classify (e.g. ``#v1.2.3``) land on ``branch``; see ``GitUrl`` for why that is safe.
+
         Args:
             value: The string to parse.
 
@@ -49,7 +59,13 @@ class PackageSource(BaseModel):
         """
         if is_repo_url(value):
             git_url = GitUrl(value)
-            return GitSource(url=git_url.repo_base_url, branch=git_url.ref)
+            ref, ref_kind = git_url.ref, git_url.ref_kind
+            return GitSource(
+                url=git_url.repo_base_url,
+                branch=ref if ref_kind == "branch" else None,
+                tag=ref if ref_kind == "tag" else None,
+                commit=ref if ref_kind == "commit" else None,
+            )
 
         if is_local_repo(value):
             return GitSource(url=value)
@@ -78,6 +94,11 @@ class GitSource(PackageSource):
     tag: str | None = None
 
     def version_id(self) -> str:
+        """The ref this source pins, most specific first.
+
+        Returns:
+            The commit, tag, or branch -- or ``"HEAD"`` when no ref is pinned.
+        """
         return self.commit or self.tag or self.branch or "HEAD"
 
     @property
@@ -102,6 +123,11 @@ class ContainerImageSource(PackageSource):
     digest: str | None = None
 
     def version_id(self) -> str:
+        """The most specific identifier this source pins.
+
+        Returns:
+            The digest if one is pinned, otherwise the tag.
+        """
         return self.digest or self.tag
 
     @property

--- a/test/aibs_informatics_cdk_lib/common/test_git.py
+++ b/test/aibs_informatics_cdk_lib/common/test_git.py
@@ -1,15 +1,23 @@
+from unittest.mock import call, patch
+
+import pytest
 from aibs_informatics_test_resources import BaseTest
 from pytest import mark, param
 
 from aibs_informatics_cdk_lib.common.git import (
+    GitUrl,
     clone_repo,
     construct_repo_path,
     get_commit_hash,
+    get_commit_hash_from_url,
     get_repo_name,
     get_repo_url_components,
     is_local_repo,
     is_repo_url,
 )
+
+FULL_SHA = "a" * 40
+SHORT_SHA = "abc1234"
 
 
 @mark.parametrize(
@@ -85,11 +93,164 @@ from aibs_informatics_cdk_lib.common.git import (
             ("git@github.com:github/octoforce-actions.git", "v1.0.0"),
             id="ssh branch2",
         ),
+        param(
+            "https://github.com/org/package/releases/tag/v1.0.0",
+            ("https://github.com/org/package.git", "v1.0.0"),
+            id="https releases/tag",
+        ),
+        param(
+            f"https://github.com/org/package/commit/{SHORT_SHA}",
+            ("https://github.com/org/package.git", SHORT_SHA),
+            id="https commit",
+        ),
+        param(
+            "git@github.com:org/package.git#refs/heads/branch/name",
+            ("git@github.com:org/package.git", "branch/name"),
+            id="ssh refs/heads is reported by short name",
+        ),
+        param(
+            "git@github.com:org/package.git#refs/tags/v1.0.0",
+            ("git@github.com:org/package.git", "v1.0.0"),
+            id="ssh refs/tags is reported by short name",
+        ),
     ],
 )
 def test__get_url_components(repo_url, expected_components):
     git_url_components = get_repo_url_components(repo_url)
     assert git_url_components == expected_components
+
+
+@mark.parametrize(
+    "repo_url, expected_ref, expected_ref_kind",
+    [
+        param("git@github.com:org/package.git", None, None, id="no ref"),
+        param(
+            "git@github.com:org/package.git#refs/heads/main",
+            "main",
+            "branch",
+            id="refs/heads is a branch",
+        ),
+        param(
+            "https://github.com/org/package/tree/refs/heads/release/1.0",
+            "release/1.0",
+            "branch",
+            id="tree refs/heads is a branch",
+        ),
+        param(
+            "git@github.com:org/package.git#refs/tags/v1.2.3",
+            "v1.2.3",
+            "tag",
+            id="refs/tags is a tag",
+        ),
+        param(
+            "https://github.com/org/package/releases/tag/v1.2.3",
+            "v1.2.3",
+            "tag",
+            id="releases/tag is a tag",
+        ),
+        param(
+            f"https://github.com/org/package/commit/{SHORT_SHA}",
+            SHORT_SHA,
+            "commit",
+            id="commit path is a commit",
+        ),
+        param(
+            f"https://github.com/org/package/commit/{FULL_SHA}",
+            FULL_SHA,
+            "commit",
+            id="commit path with full sha is a commit",
+        ),
+        param(
+            f"git@github.com:org/package.git#{SHORT_SHA}",
+            SHORT_SHA,
+            "commit",
+            id="bare short sha is a commit",
+        ),
+        param(
+            f"git@github.com:org/package.git@{FULL_SHA}",
+            FULL_SHA,
+            "commit",
+            id="bare full sha is a commit",
+        ),
+        # Anything the URL does not classify is reported as a branch. `/tree/` is GitHub's
+        # segment for branches, tags and SHAs alike, and branch vs tag changes nothing
+        # downstream -- only commit does.
+        param("git@github.com:org/package.git#main", "main", "branch", id="ambiguous name"),
+        param("git@github.com:org/package.git#v1.2.3", "v1.2.3", "branch", id="ambiguous tag"),
+        param("https://github.com/org/package/tree/main", "main", "branch", id="ambiguous tree"),
+        param(
+            "git@github.com:org/package.git#abc123",
+            "abc123",
+            "branch",
+            id="six hex chars is too short to be a sha",
+        ),
+    ],
+)
+def test__git_url__ref_and_ref_kind(repo_url, expected_ref, expected_ref_kind):
+    git_url = GitUrl(repo_url)
+    assert git_url.ref == expected_ref
+    assert git_url.ref_kind == expected_ref_kind
+
+
+@patch("aibs_informatics_cdk_lib.common.git.subprocess.check_output")
+def test__get_commit_hash_from_url__commit_ref_short_circuits(mock_check_output):
+    """A commit SHA is already a commit hash -- ls-remote would report nothing for it."""
+    assert get_commit_hash_from_url(f"git@github.com:org/package.git#{FULL_SHA}") == FULL_SHA
+    mock_check_output.assert_not_called()
+
+
+@patch("aibs_informatics_cdk_lib.common.git.subprocess.check_output", return_value=b"")
+def test__get_commit_hash_from_url__unresolvable_ref_raises(mock_check_output):
+    with pytest.raises(ValueError, match="Could not resolve ref 'no-such-branch'"):
+        get_commit_hash_from_url("git@github.com:org/package.git#no-such-branch")
+
+
+@patch("aibs_informatics_cdk_lib.common.git.subprocess.check_output")
+def test__construct_repo_path__commit_ref_uses_the_sha(mock_check_output, tmp_path):
+    target_path = construct_repo_path(f"git@github.com:org/package.git#{FULL_SHA}", tmp_path)
+    assert target_path == tmp_path / f"package_{FULL_SHA}"
+    mock_check_output.assert_not_called()
+
+
+@patch("aibs_informatics_cdk_lib.common.git.subprocess.check_call")
+def test__clone_repo__commit_ref_fetches_and_checks_out(mock_check_call, tmp_path):
+    """`git clone --branch` takes branch and tag names only, so a commit needs a checkout."""
+    target_path = clone_repo(f"git@github.com:org/package.git#{FULL_SHA}", tmp_path)
+
+    assert target_path == tmp_path / f"package_{FULL_SHA}"
+    assert mock_check_call.call_args_list == [
+        call(
+            [
+                "git",
+                "clone",
+                "git@github.com:org/package.git",
+                target_path.as_posix(),
+                "--single-branch",
+            ]
+        ),
+        call(["git", "fetch", "origin", FULL_SHA], cwd=target_path),
+        call(["git", "checkout", FULL_SHA], cwd=target_path),
+    ]
+
+
+@patch("aibs_informatics_cdk_lib.common.git.get_commit_hash_from_url", return_value="b" * 40)
+@patch("aibs_informatics_cdk_lib.common.git.subprocess.check_call")
+def test__clone_repo__tag_ref_uses_branch_flag(mock_check_call, mock_get_commit_hash, tmp_path):
+    target_path = clone_repo("https://github.com/org/package/releases/tag/v1.0.0", tmp_path)
+
+    assert mock_check_call.call_args_list == [
+        call(
+            [
+                "git",
+                "clone",
+                "https://github.com/org/package.git",
+                target_path.as_posix(),
+                "--single-branch",
+                "--branch",
+                "v1.0.0",
+            ]
+        )
+    ]
 
 
 class GitTests(BaseTest):
@@ -135,7 +296,9 @@ class GitTests(BaseTest):
 
         p1a = construct_repo_path("https://github.com/github/check-all/tree/v0.4.0", root)
         p1b = construct_repo_path("git@github.com:github/check-all.git@v0.4.0", root)
-        p2 = construct_repo_path("https://github.com/github/check-all/tree/0.3.0", root)
+        # NOTE: this used to read `0.3.0`, a tag that does not exist. It "passed" only
+        # because an unresolvable ref used to yield an empty commit hash.
+        p2 = construct_repo_path("https://github.com/github/check-all/tree/v0.3.0", root)
         assert p1a == p1b
         assert p1a != p2
 

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
@@ -12,10 +12,8 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
     GitSource,
-    PackageSource,
 )
 from test.aibs_informatics_cdk_lib.base import CdkBaseTest
-
 
 # ---------------------------------------------------------------------------
 # AssetsMixin._normalize_source
@@ -122,7 +120,9 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
         )
         result = assets.AIBS_INFORMATICS_AWS_LAMBDA
         assert isinstance(result, str)
-        assert result == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890"
+        assert result == (
+            "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890"
+        )
 
     @patch.object(AssetsMixin, "resolve_repo_path")
     def test__AIBS_INFORMATICS_AWS_LAMBDA__git_source_calls_resolve(self, mock_resolve):
@@ -141,8 +141,13 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
         # Access the property - we expect it to call resolve_repo_path
         # but the DockerImageAsset constructor will fail without a real directory,
         # so we patch that too
-        with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.aws_ecr_assets.DockerImageAsset"):
-            with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash", return_value="fakehash"):
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.aws_ecr_assets.DockerImageAsset"
+        ):
+            with patch(
+                "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash",
+                return_value="fakehash",
+            ):
                 assets.AIBS_INFORMATICS_AWS_LAMBDA
 
         mock_resolve.assert_called_once_with(
@@ -205,7 +210,10 @@ class TestAIBSInformaticsCodeAssets(CdkBaseTest):
         mock_path.as_posix.return_value = "/tmp/fake-repo"
         mock_resolve.return_value = mock_path
 
-        with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash", return_value="fakehash"):
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash",
+            return_value="fakehash",
+        ):
             assets.AIBS_INFORMATICS_AWS_LAMBDA
 
         mock_resolve.assert_called_once_with(

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
@@ -1,0 +1,259 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
+    AIBS_INFORMATICS_AWS_LAMBDA_REPO,
+    AIBSInformaticsAssets,
+    AIBSInformaticsCodeAssets,
+    AIBSInformaticsDockerAssets,
+    AssetsMixin,
+)
+from aibs_informatics_cdk_lib.constructs_.assets.source import (
+    ContainerImageSource,
+    GitSource,
+    PackageSource,
+)
+from test.aibs_informatics_cdk_lib.base import CdkBaseTest
+
+
+# ---------------------------------------------------------------------------
+# AssetsMixin._normalize_source
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSource:
+    def test__none_returns_default_git_source(self):
+        source = AssetsMixin._normalize_source(None, "git@github.com:org/repo.git")
+        assert isinstance(source, GitSource)
+        assert source.url == "git@github.com:org/repo.git"
+
+    def test__str_git_url_returns_git_source(self):
+        source = AssetsMixin._normalize_source(
+            "git@github.com:org/repo.git#main", "git@github.com:org/default.git"
+        )
+        assert isinstance(source, GitSource)
+        assert source.url == "git@github.com:org/repo.git"
+        assert source.branch == "main"
+
+    def test__str_container_image_returns_container_source(self):
+        source = AssetsMixin._normalize_source(
+            "ghcr.io/org/repo:v1.2.3", "git@github.com:org/default.git"
+        )
+        assert isinstance(source, ContainerImageSource)
+        assert source.image == "ghcr.io/org/repo"
+        assert source.tag == "v1.2.3"
+
+    def test__package_source_passed_through(self):
+        original = GitSource(url="git@github.com:org/repo.git", tag="v2.0")
+        source = AssetsMixin._normalize_source(original, "git@github.com:org/default.git")
+        assert source is original
+
+    def test__container_image_source_passed_through(self):
+        original = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
+        source = AssetsMixin._normalize_source(original, "git@github.com:org/default.git")
+        assert source is original
+
+
+# ---------------------------------------------------------------------------
+# AIBSInformaticsDockerAssets
+# ---------------------------------------------------------------------------
+
+
+class TestAIBSInformaticsDockerAssets(CdkBaseTest):
+    def test__init__default_source(self):
+        stack = self.get_dummy_stack("test")
+        assets = AIBSInformaticsDockerAssets(stack, "DockerAssets", self.env_base)
+        assert isinstance(assets._source, GitSource)
+        assert assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+
+    def test__init__str_source_backward_compat(self):
+        stack = self.get_dummy_stack("test")
+        repo_url = "git@github.com:org/custom-repo.git"
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+        )
+        assert isinstance(assets._source, GitSource)
+        assert assets._source.url == repo_url
+        # Backward compatibility attribute
+        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == repo_url
+
+    def test__init__git_source(self):
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        assert assets._source is source
+        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == "git@github.com:org/repo.git"
+
+    def test__init__container_image_source(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(
+            image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda", tag="v1.2.3"
+        )
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        assert assets._source is source
+        # Backward compat attribute falls back to default
+        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+
+    def test__AIBS_INFORMATICS_AWS_LAMBDA__container_image_returns_uri(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(
+            image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda", tag="v1.2.3"
+        )
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        result = assets.AIBS_INFORMATICS_AWS_LAMBDA
+        assert isinstance(result, str)
+        assert result == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:v1.2.3"
+
+    def test__AIBS_INFORMATICS_AWS_LAMBDA__container_image_with_digest(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(
+            image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda",
+            digest="sha256:abcdef1234567890",
+        )
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        result = assets.AIBS_INFORMATICS_AWS_LAMBDA
+        assert isinstance(result, str)
+        assert result == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890"
+
+    @patch.object(AssetsMixin, "resolve_repo_path")
+    def test__AIBS_INFORMATICS_AWS_LAMBDA__git_source_calls_resolve(self, mock_resolve):
+        """When using GitSource, the property should call resolve_repo_path with the ref URL."""
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        # Mock resolve_repo_path to avoid actual git clone
+        mock_path = MagicMock()
+        mock_path.as_posix.return_value = "/tmp/fake-repo"
+        mock_path.resolve.return_value = "/tmp/fake-repo"
+        mock_resolve.return_value = mock_path
+
+        # Access the property - we expect it to call resolve_repo_path
+        # but the DockerImageAsset constructor will fail without a real directory,
+        # so we patch that too
+        with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.aws_ecr_assets.DockerImageAsset"):
+            with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash", return_value="fakehash"):
+                assets.AIBS_INFORMATICS_AWS_LAMBDA
+
+        mock_resolve.assert_called_once_with(
+            "git@github.com:org/repo.git#v1.0.0",
+            "AIBS_INFORMATICS_AWS_LAMBDA_REPO",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AIBSInformaticsCodeAssets
+# ---------------------------------------------------------------------------
+
+
+class TestAIBSInformaticsCodeAssets(CdkBaseTest):
+    def test__init__default_source(self):
+        stack = self.get_dummy_stack("test")
+        assets = AIBSInformaticsCodeAssets(stack, "CodeAssets", self.env_base)
+        assert isinstance(assets._source, GitSource)
+        assert assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+
+    def test__init__str_source_backward_compat(self):
+        stack = self.get_dummy_stack("test")
+        repo_url = "git@github.com:org/custom-repo.git"
+        assets = AIBSInformaticsCodeAssets(
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+        )
+        assert isinstance(assets._source, GitSource)
+        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == repo_url
+
+    def test__init__container_image_source_accepted(self):
+        """ContainerImageSource is accepted at init time (lazy error)."""
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
+        # Should not raise at construction time
+        assets = AIBSInformaticsCodeAssets(
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        assert isinstance(assets._source, ContainerImageSource)
+
+    def test__AIBS_INFORMATICS_AWS_LAMBDA__container_image_raises_type_error(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
+        assets = AIBSInformaticsCodeAssets(
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        with pytest.raises(TypeError, match="requires a GitSource"):
+            assets.AIBS_INFORMATICS_AWS_LAMBDA
+
+    @patch.object(AssetsMixin, "resolve_repo_path")
+    def test__AIBS_INFORMATICS_AWS_LAMBDA__git_source_calls_resolve(self, mock_resolve):
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git", branch="main")
+        assets = AIBSInformaticsCodeAssets(
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+
+        mock_path = MagicMock()
+        mock_path.__str__ = MagicMock(return_value="/tmp/fake-repo")
+        mock_path.resolve.return_value = mock_path
+        mock_path.as_posix.return_value = "/tmp/fake-repo"
+        mock_resolve.return_value = mock_path
+
+        with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash", return_value="fakehash"):
+            assets.AIBS_INFORMATICS_AWS_LAMBDA
+
+        mock_resolve.assert_called_once_with(
+            "git@github.com:org/repo.git#main",
+            "AIBS_INFORMATICS_AWS_LAMBDA_REPO",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AIBSInformaticsAssets
+# ---------------------------------------------------------------------------
+
+
+class TestAIBSInformaticsAssets(CdkBaseTest):
+    def test__init__default_passes_through(self):
+        stack = self.get_dummy_stack("test")
+        assets = AIBSInformaticsAssets(stack, "Assets", self.env_base)
+        assert isinstance(assets.code_assets._source, GitSource)
+        assert isinstance(assets.docker_assets._source, GitSource)
+        assert assets.code_assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        assert assets.docker_assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+
+    def test__init__git_source_passed_to_both(self):
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        assets = AIBSInformaticsAssets(
+            stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        assert assets.code_assets._source is source
+        assert assets.docker_assets._source is source
+
+    def test__init__container_image_source_passed_to_both(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
+        assets = AIBSInformaticsAssets(
+            stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=source
+        )
+        # Both should receive the source (code_assets will fail lazily on property access)
+        assert isinstance(assets.docker_assets._source, ContainerImageSource)
+        assert isinstance(assets.code_assets._source, ContainerImageSource)
+
+    def test__init__str_source_backward_compat(self):
+        stack = self.get_dummy_stack("test")
+        repo_url = "git@github.com:org/custom.git"
+        assets = AIBSInformaticsAssets(
+            stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+        )
+        assert isinstance(assets.code_assets._source, GitSource)
+        assert isinstance(assets.docker_assets._source, GitSource)
+        assert assets.code_assets._source.url == "git@github.com:org/custom.git"
+        assert assets.docker_assets._source.url == "git@github.com:org/custom.git"

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
@@ -9,7 +9,6 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
     AIBSInformaticsCodeAssets,
     AIBSInformaticsDockerAssets,
     AssetsMixin,
-    _pop_deprecated_source_kwarg,
 )
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
@@ -56,11 +55,7 @@ class TestNormalizeSource:
         assert source is original
 
     def test__unsupported_package_source_raises(self):
-        """An unrecognized subclass must be rejected here, not deep in a cached_property.
-
-        Downstream code reaches for source-kind-specific properties, so passing one
-        through would surface as an AttributeError far from the actual mistake.
-        """
+        """An unrecognized subclass must be rejected here, not deep in a cached_property."""
 
         class CustomSource(PackageSource):
             source_type: str = "custom"
@@ -76,59 +71,45 @@ class TestNormalizeSource:
 
 class TestResolveDeprecatedSource:
     def test__neither_supplied_returns_none(self):
-        assert AssetsMixin._resolve_deprecated_source(None, None) is None
+        assert AssetsMixin._resolve_deprecated_source(None, {}) is None
 
     def test__current_param_returned_without_warning(self):
         source = GitSource(url="git@github.com:org/repo.git")
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            assert AssetsMixin._resolve_deprecated_source(source, None) is source
+            assert AssetsMixin._resolve_deprecated_source(source, {}) is source
 
-    def test__deprecated_param_warns_and_is_returned(self):
+    def test__deprecated_kwarg_is_popped_warned_and_returned(self):
         source = GitSource(url="git@github.com:org/repo.git")
+        kwargs: dict = {"aibs_informatics_aws_lambda_repo": source}
         with pytest.warns(DeprecationWarning, match="aibs_informatics_aws_lambda_repo"):
-            assert AssetsMixin._resolve_deprecated_source(None, source) is source
+            assert AssetsMixin._resolve_deprecated_source(None, kwargs) is source
+        assert kwargs == {}
 
     def test__both_supplied_raises(self):
         with pytest.raises(ValueError, match="Cannot specify both"):
-            AssetsMixin._resolve_deprecated_source("a", "b")
+            AssetsMixin._resolve_deprecated_source("a", {"aibs_informatics_aws_lambda_repo": "b"})
 
+    @pytest.mark.parametrize(
+        "kwargs, match",
+        [
+            pytest.param(
+                {"aibs_informatics_aws_lambda_rep": "git@github.com:org/repo.git"},
+                "unexpected keyword argument 'aibs_informatics_aws_lambda_rep'",
+                id="near_miss_on_the_alias",
+            ),
+            pytest.param({"beta": None, "alpha": None}, "'alpha', 'beta'", id="all_reported"),
+        ],
+    )
+    def test__unexpected_keyword_raises(self, kwargs: dict, match: str):
+        """**kwargs must not silently swallow a near miss like a misspelled alias.
 
-# ---------------------------------------------------------------------------
-# _pop_deprecated_source_kwarg
-# ---------------------------------------------------------------------------
-
-
-class TestPopDeprecatedSourceKwarg:
-    def test__deprecated_key_is_popped_and_returned(self):
-        kwargs: dict = {"aibs_informatics_aws_lambda_repo": "git@github.com:org/repo.git"}
-        assert _pop_deprecated_source_kwarg(kwargs, "Owner") == "git@github.com:org/repo.git"
-        assert kwargs == {}
-
-    def test__empty_kwargs_returns_none(self):
-        assert _pop_deprecated_source_kwarg({}, "Owner") is None
-
-    def test__unexpected_keyword_raises(self):
-        """**kwargs must not silently swallow a near miss.
-
-        A typo like `aibs_informatics_aws_lambda_rep` would otherwise leave the construct
-        on its default source while the caller believed they had pinned a version, which
-        is a silently wrong deploy rather than a loud failure.
+        That the message names the concrete construct is pinned by
+        TestAIBSInformaticsDockerAssets.test__init__misspelled_kwarg_raises; asserting it
+        here would only ever show `AssetsMixin`, which has no __init__.
         """
-        with pytest.raises(
-            TypeError, match="unexpected keyword argument 'aibs_informatics_aws_lambda_rep'"
-        ):
-            _pop_deprecated_source_kwarg(
-                {"aibs_informatics_aws_lambda_rep": "git@github.com:org/repo.git"}, "Owner"
-            )
-
-    def test__unexpected_keywords_are_all_reported(self):
-        with pytest.raises(TypeError, match="'alpha', 'beta'"):
-            _pop_deprecated_source_kwarg({"beta": None, "alpha": None}, "Owner")
-
-    def test__owner_name_is_in_the_message(self):
-        with pytest.raises(TypeError, match=r"MyConstruct\.__init__\(\)"):
-            _pop_deprecated_source_kwarg({"nope": None}, "MyConstruct")
+        with pytest.raises(TypeError, match=match):
+            AssetsMixin._resolve_deprecated_source(None, kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +157,9 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
     def test__init__misspelled_kwarg_raises(self):
         """A near miss on the deprecated alias must fail, not fall back to the default."""
         stack = self.get_dummy_stack("test")
-        with pytest.raises(TypeError, match="unexpected keyword argument"):
+        with pytest.raises(
+            TypeError, match=r"AIBSInformaticsDockerAssets\.__init__\(\) got an unexpected keyword"
+        ):
             AIBSInformaticsDockerAssets(
                 stack,
                 "DockerAssets",
@@ -436,11 +419,7 @@ class TestAIBSInformaticsAssets(CdkBaseTest):
         assert assets.docker_assets.source.image_uri == "ghcr.io/org/repo:v1"
 
     def test__init__no_deprecated_repo_kwarg(self):
-        """This construct never shipped an `aibs_informatics_aws_lambda_repo` parameter.
-
-        `main` takes only (scope, construct_id, env_base, runtime), so there is nothing to
-        stay compatible with here and no shim to maintain.
-        """
+        """This construct never shipped an `aibs_informatics_aws_lambda_repo` parameter."""
         stack = self.get_dummy_stack("test")
         with pytest.raises(TypeError, match="aibs_informatics_aws_lambda_repo"):
             AIBSInformaticsAssets(

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
@@ -13,6 +13,7 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
     GitSource,
+    PackageSource,
 )
 from test.aibs_informatics_cdk_lib.base import CdkBaseTest
 
@@ -52,6 +53,19 @@ class TestNormalizeSource:
         original = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
         source = AssetsMixin._normalize_source(original, "git@github.com:org/default.git")
         assert source is original
+
+    def test__unsupported_package_source_raises(self):
+        """An unrecognized subclass must be rejected here, not deep in a cached_property.
+
+        Downstream code reaches for source-kind-specific properties, so passing one
+        through would surface as an AttributeError far from the actual mistake.
+        """
+
+        class CustomSource(PackageSource):
+            source_type: str = "custom"
+
+        with pytest.raises(TypeError, match="Unsupported package source type: CustomSource"):
+            AssetsMixin._normalize_source(CustomSource(), "git@github.com:org/default.git")
 
 
 # ---------------------------------------------------------------------------

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
@@ -9,6 +9,7 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
     AIBSInformaticsCodeAssets,
     AIBSInformaticsDockerAssets,
     AssetsMixin,
+    _pop_deprecated_source_kwarg,
 )
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
@@ -94,6 +95,43 @@ class TestResolveDeprecatedSource:
 
 
 # ---------------------------------------------------------------------------
+# _pop_deprecated_source_kwarg
+# ---------------------------------------------------------------------------
+
+
+class TestPopDeprecatedSourceKwarg:
+    def test__deprecated_key_is_popped_and_returned(self):
+        kwargs: dict = {"aibs_informatics_aws_lambda_repo": "git@github.com:org/repo.git"}
+        assert _pop_deprecated_source_kwarg(kwargs, "Owner") == "git@github.com:org/repo.git"
+        assert kwargs == {}
+
+    def test__empty_kwargs_returns_none(self):
+        assert _pop_deprecated_source_kwarg({}, "Owner") is None
+
+    def test__unexpected_keyword_raises(self):
+        """**kwargs must not silently swallow a near miss.
+
+        A typo like `aibs_informatics_aws_lambda_rep` would otherwise leave the construct
+        on its default source while the caller believed they had pinned a version, which
+        is a silently wrong deploy rather than a loud failure.
+        """
+        with pytest.raises(
+            TypeError, match="unexpected keyword argument 'aibs_informatics_aws_lambda_rep'"
+        ):
+            _pop_deprecated_source_kwarg(
+                {"aibs_informatics_aws_lambda_rep": "git@github.com:org/repo.git"}, "Owner"
+            )
+
+    def test__unexpected_keywords_are_all_reported(self):
+        with pytest.raises(TypeError, match="'alpha', 'beta'"):
+            _pop_deprecated_source_kwarg({"beta": None, "alpha": None}, "Owner")
+
+    def test__owner_name_is_in_the_message(self):
+        with pytest.raises(TypeError, match=r"MyConstruct\.__init__\(\)"):
+            _pop_deprecated_source_kwarg({"nope": None}, "MyConstruct")
+
+
+# ---------------------------------------------------------------------------
 # AIBSInformaticsDockerAssets
 # ---------------------------------------------------------------------------
 
@@ -133,6 +171,17 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
                 self.env_base,
                 aibs_informatics_aws_lambda_source="git@github.com:org/a.git",
                 aibs_informatics_aws_lambda_repo="git@github.com:org/b.git",
+            )
+
+    def test__init__misspelled_kwarg_raises(self):
+        """A near miss on the deprecated alias must fail, not fall back to the default."""
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            AIBSInformaticsDockerAssets(
+                stack,
+                "DockerAssets",
+                self.env_base,
+                aibs_informatics_aws_lambda_rep="git@github.com:org/custom.git",
             )
 
     def test__init__git_source(self):
@@ -353,8 +402,8 @@ class TestAIBSInformaticsAssets(CdkBaseTest):
             stack,
             "Assets",
             self.env_base,
-            code_source=code_source,
-            docker_source=docker_source,
+            aibs_informatics_aws_lambda_code_source=code_source,
+            aibs_informatics_aws_lambda_docker_source=docker_source,
         )
         assert assets.code_assets.source is code_source
         assert assets.docker_assets.source is docker_source
@@ -362,7 +411,12 @@ class TestAIBSInformaticsAssets(CdkBaseTest):
     def test__init__only_docker_source_leaves_code_source_at_default(self):
         stack = self.get_dummy_stack("test")
         docker_source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1.0.0")
-        assets = AIBSInformaticsAssets(stack, "Assets", self.env_base, docker_source=docker_source)
+        assets = AIBSInformaticsAssets(
+            stack,
+            "Assets",
+            self.env_base,
+            aibs_informatics_aws_lambda_docker_source=docker_source,
+        )
         assert isinstance(assets.code_assets.source, GitSource)
         assert assets.code_assets.source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
         assert assets.docker_assets.source is docker_source
@@ -373,33 +427,25 @@ class TestAIBSInformaticsAssets(CdkBaseTest):
             stack,
             "Assets",
             self.env_base,
-            code_source="git@github.com:org/custom.git",
-            docker_source="ghcr.io/org/repo:v1",
+            aibs_informatics_aws_lambda_code_source="git@github.com:org/custom.git",
+            aibs_informatics_aws_lambda_docker_source="ghcr.io/org/repo:v1",
         )
         assert isinstance(assets.code_assets.source, GitSource)
         assert assets.code_assets.source.url == "git@github.com:org/custom.git"
         assert isinstance(assets.docker_assets.source, ContainerImageSource)
         assert assets.docker_assets.source.image_uri == "ghcr.io/org/repo:v1"
 
-    def test__init__deprecated_repo_kwarg_sets_both(self):
-        stack = self.get_dummy_stack("test")
-        repo_url = "git@github.com:org/custom.git"
-        with pytest.warns(DeprecationWarning, match="aibs_informatics_aws_lambda_repo"):
-            assets = AIBSInformaticsAssets(
-                stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
-            )
-        assert isinstance(assets.code_assets.source, GitSource)
-        assert isinstance(assets.docker_assets.source, GitSource)
-        assert assets.code_assets.source.url == repo_url
-        assert assets.docker_assets.source.url == repo_url
+    def test__init__no_deprecated_repo_kwarg(self):
+        """This construct never shipped an `aibs_informatics_aws_lambda_repo` parameter.
 
-    def test__init__deprecated_repo_kwarg_with_new_kwarg_raises(self):
+        `main` takes only (scope, construct_id, env_base, runtime), so there is nothing to
+        stay compatible with here and no shim to maintain.
+        """
         stack = self.get_dummy_stack("test")
-        with pytest.raises(ValueError, match="Cannot specify both"):
+        with pytest.raises(TypeError, match="aibs_informatics_aws_lambda_repo"):
             AIBSInformaticsAssets(
                 stack,
                 "Assets",
                 self.env_base,
-                docker_source="ghcr.io/org/repo:v1",
                 aibs_informatics_aws_lambda_repo="git@github.com:org/custom.git",
             )

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,10 +13,8 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
     GitSource,
-    PackageSource,
 )
 from test.aibs_informatics_cdk_lib.base import CdkBaseTest
-
 
 # ---------------------------------------------------------------------------
 # AssetsMixin._normalize_source
@@ -56,6 +55,31 @@ class TestNormalizeSource:
 
 
 # ---------------------------------------------------------------------------
+# AssetsMixin._resolve_deprecated_source
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDeprecatedSource:
+    def test__neither_supplied_returns_none(self):
+        assert AssetsMixin._resolve_deprecated_source(None, None) is None
+
+    def test__current_param_returned_without_warning(self):
+        source = GitSource(url="git@github.com:org/repo.git")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert AssetsMixin._resolve_deprecated_source(source, None) is source
+
+    def test__deprecated_param_warns_and_is_returned(self):
+        source = GitSource(url="git@github.com:org/repo.git")
+        with pytest.warns(DeprecationWarning, match="aibs_informatics_aws_lambda_repo"):
+            assert AssetsMixin._resolve_deprecated_source(None, source) is source
+
+    def test__both_supplied_raises(self):
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            AssetsMixin._resolve_deprecated_source("a", "b")
+
+
+# ---------------------------------------------------------------------------
 # AIBSInformaticsDockerAssets
 # ---------------------------------------------------------------------------
 
@@ -64,28 +88,46 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
     def test__init__default_source(self):
         stack = self.get_dummy_stack("test")
         assets = AIBSInformaticsDockerAssets(stack, "DockerAssets", self.env_base)
-        assert isinstance(assets._source, GitSource)
-        assert assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        assert isinstance(assets.source, GitSource)
+        assert assets.source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
 
-    def test__init__str_source_backward_compat(self):
+    def test__init__str_source(self):
         stack = self.get_dummy_stack("test")
         repo_url = "git@github.com:org/custom-repo.git"
         assets = AIBSInformaticsDockerAssets(
-            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=repo_url
         )
-        assert isinstance(assets._source, GitSource)
-        assert assets._source.url == repo_url
-        # Backward compatibility attribute
-        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == repo_url
+        assert isinstance(assets.source, GitSource)
+        assert assets.source.url == repo_url
+
+    def test__init__deprecated_repo_kwarg_still_works(self):
+        stack = self.get_dummy_stack("test")
+        repo_url = "git@github.com:org/custom-repo.git"
+        with pytest.warns(DeprecationWarning, match="aibs_informatics_aws_lambda_repo"):
+            assets = AIBSInformaticsDockerAssets(
+                stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+            )
+        assert isinstance(assets.source, GitSource)
+        assert assets.source.url == repo_url
+
+    def test__init__both_source_kwargs_raises(self):
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            AIBSInformaticsDockerAssets(
+                stack,
+                "DockerAssets",
+                self.env_base,
+                aibs_informatics_aws_lambda_source="git@github.com:org/a.git",
+                aibs_informatics_aws_lambda_repo="git@github.com:org/b.git",
+            )
 
     def test__init__git_source(self):
         stack = self.get_dummy_stack("test")
         source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
         assets = AIBSInformaticsDockerAssets(
-            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
-        assert assets._source is source
-        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == "git@github.com:org/repo.git"
+        assert assets.source is source
 
     def test__init__container_image_source(self):
         stack = self.get_dummy_stack("test")
@@ -93,11 +135,30 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
             image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda", tag="v1.2.3"
         )
         assets = AIBSInformaticsDockerAssets(
-            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
-        assert assets._source is source
-        # Backward compat attribute falls back to default
-        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        assert assets.source is source
+
+    def test__AIBS_INFORMATICS_AWS_LAMBDA_REPO__git_source_warns_and_returns_url(self):
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
+        )
+        with pytest.warns(DeprecationWarning, match="AIBS_INFORMATICS_AWS_LAMBDA_REPO"):
+            assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == "git@github.com:org/repo.git"
+
+    def test__AIBS_INFORMATICS_AWS_LAMBDA_REPO__container_image_source_is_none(self):
+        """A Container Image Source has no repo URL, so the shim must not invent one."""
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(
+            image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda", tag="v1.2.3"
+        )
+        assets = AIBSInformaticsDockerAssets(
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
+        )
+        with pytest.warns(DeprecationWarning, match="AIBS_INFORMATICS_AWS_LAMBDA_REPO"):
+            assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO is None
 
     def test__AIBS_INFORMATICS_AWS_LAMBDA__container_image_returns_uri(self):
         stack = self.get_dummy_stack("test")
@@ -105,7 +166,7 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
             image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda", tag="v1.2.3"
         )
         assets = AIBSInformaticsDockerAssets(
-            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
         result = assets.AIBS_INFORMATICS_AWS_LAMBDA
         assert isinstance(result, str)
@@ -118,11 +179,13 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
             digest="sha256:abcdef1234567890",
         )
         assets = AIBSInformaticsDockerAssets(
-            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
         result = assets.AIBS_INFORMATICS_AWS_LAMBDA
         assert isinstance(result, str)
-        assert result == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890"
+        assert (
+            result == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890"
+        )
 
     @patch.object(AssetsMixin, "resolve_repo_path")
     def test__AIBS_INFORMATICS_AWS_LAMBDA__git_source_calls_resolve(self, mock_resolve):
@@ -130,7 +193,7 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
         stack = self.get_dummy_stack("test")
         source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
         assets = AIBSInformaticsDockerAssets(
-            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
         # Mock resolve_repo_path to avoid actual git clone
         mock_path = MagicMock()
@@ -141,8 +204,13 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
         # Access the property - we expect it to call resolve_repo_path
         # but the DockerImageAsset constructor will fail without a real directory,
         # so we patch that too
-        with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.aws_ecr_assets.DockerImageAsset"):
-            with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash", return_value="fakehash"):
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.aws_ecr_assets.DockerImageAsset"
+        ):
+            with patch(
+                "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash",
+                return_value="fakehash",
+            ):
                 assets.AIBS_INFORMATICS_AWS_LAMBDA
 
         mock_resolve.assert_called_once_with(
@@ -160,17 +228,36 @@ class TestAIBSInformaticsCodeAssets(CdkBaseTest):
     def test__init__default_source(self):
         stack = self.get_dummy_stack("test")
         assets = AIBSInformaticsCodeAssets(stack, "CodeAssets", self.env_base)
-        assert isinstance(assets._source, GitSource)
-        assert assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        assert isinstance(assets.source, GitSource)
+        assert assets.source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
 
-    def test__init__str_source_backward_compat(self):
+    def test__init__str_source(self):
         stack = self.get_dummy_stack("test")
         repo_url = "git@github.com:org/custom-repo.git"
         assets = AIBSInformaticsCodeAssets(
-            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_source=repo_url
         )
-        assert isinstance(assets._source, GitSource)
-        assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == repo_url
+        assert isinstance(assets.source, GitSource)
+        assert assets.source.url == repo_url
+
+    def test__init__deprecated_repo_kwarg_still_works(self):
+        stack = self.get_dummy_stack("test")
+        repo_url = "git@github.com:org/custom-repo.git"
+        with pytest.warns(DeprecationWarning, match="aibs_informatics_aws_lambda_repo"):
+            assets = AIBSInformaticsCodeAssets(
+                stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+            )
+        assert isinstance(assets.source, GitSource)
+        assert assets.source.url == repo_url
+
+    def test__AIBS_INFORMATICS_AWS_LAMBDA_REPO__git_source_warns_and_returns_url(self):
+        stack = self.get_dummy_stack("test")
+        repo_url = "git@github.com:org/custom-repo.git"
+        assets = AIBSInformaticsCodeAssets(
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_source=repo_url
+        )
+        with pytest.warns(DeprecationWarning, match="AIBS_INFORMATICS_AWS_LAMBDA_REPO"):
+            assert assets.AIBS_INFORMATICS_AWS_LAMBDA_REPO == repo_url
 
     def test__init__container_image_source_accepted(self):
         """ContainerImageSource is accepted at init time (lazy error)."""
@@ -178,15 +265,27 @@ class TestAIBSInformaticsCodeAssets(CdkBaseTest):
         source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
         # Should not raise at construction time
         assets = AIBSInformaticsCodeAssets(
-            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
-        assert isinstance(assets._source, ContainerImageSource)
+        assert isinstance(assets.source, ContainerImageSource)
 
     def test__AIBS_INFORMATICS_AWS_LAMBDA__container_image_raises_type_error(self):
         stack = self.get_dummy_stack("test")
         source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
         assets = AIBSInformaticsCodeAssets(
-            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_source=source
+        )
+        with pytest.raises(TypeError, match="requires a GitSource"):
+            assets.AIBS_INFORMATICS_AWS_LAMBDA
+
+    def test__AIBS_INFORMATICS_AWS_LAMBDA__container_image_str_raises_type_error(self):
+        """A str that parses to an image ref is caught at property access, not init."""
+        stack = self.get_dummy_stack("test")
+        assets = AIBSInformaticsCodeAssets(
+            stack,
+            "CodeAssets",
+            self.env_base,
+            aibs_informatics_aws_lambda_source="ghcr.io/org/repo:v1",
         )
         with pytest.raises(TypeError, match="requires a GitSource"):
             assets.AIBS_INFORMATICS_AWS_LAMBDA
@@ -196,7 +295,7 @@ class TestAIBSInformaticsCodeAssets(CdkBaseTest):
         stack = self.get_dummy_stack("test")
         source = GitSource(url="git@github.com:org/repo.git", branch="main")
         assets = AIBSInformaticsCodeAssets(
-            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack, "CodeAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
 
         mock_path = MagicMock()
@@ -205,7 +304,10 @@ class TestAIBSInformaticsCodeAssets(CdkBaseTest):
         mock_path.as_posix.return_value = "/tmp/fake-repo"
         mock_resolve.return_value = mock_path
 
-        with patch("aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash", return_value="fakehash"):
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash",
+            return_value="fakehash",
+        ):
             assets.AIBS_INFORMATICS_AWS_LAMBDA
 
         mock_resolve.assert_called_once_with(
@@ -223,37 +325,67 @@ class TestAIBSInformaticsAssets(CdkBaseTest):
     def test__init__default_passes_through(self):
         stack = self.get_dummy_stack("test")
         assets = AIBSInformaticsAssets(stack, "Assets", self.env_base)
-        assert isinstance(assets.code_assets._source, GitSource)
-        assert isinstance(assets.docker_assets._source, GitSource)
-        assert assets.code_assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
-        assert assets.docker_assets._source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        assert isinstance(assets.code_assets.source, GitSource)
+        assert isinstance(assets.docker_assets.source, GitSource)
+        assert assets.code_assets.source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        assert assets.docker_assets.source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
 
-    def test__init__git_source_passed_to_both(self):
+    def test__init__sources_are_independent(self):
+        """A container image for docker must not leak into the code assets."""
         stack = self.get_dummy_stack("test")
-        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        code_source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        docker_source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1.0.0")
         assets = AIBSInformaticsAssets(
-            stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=source
+            stack,
+            "Assets",
+            self.env_base,
+            code_source=code_source,
+            docker_source=docker_source,
         )
-        assert assets.code_assets._source is source
-        assert assets.docker_assets._source is source
+        assert assets.code_assets.source is code_source
+        assert assets.docker_assets.source is docker_source
 
-    def test__init__container_image_source_passed_to_both(self):
+    def test__init__only_docker_source_leaves_code_source_at_default(self):
         stack = self.get_dummy_stack("test")
-        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
-        assets = AIBSInformaticsAssets(
-            stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=source
-        )
-        # Both should receive the source (code_assets will fail lazily on property access)
-        assert isinstance(assets.docker_assets._source, ContainerImageSource)
-        assert isinstance(assets.code_assets._source, ContainerImageSource)
+        docker_source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1.0.0")
+        assets = AIBSInformaticsAssets(stack, "Assets", self.env_base, docker_source=docker_source)
+        assert isinstance(assets.code_assets.source, GitSource)
+        assert assets.code_assets.source.url == AIBS_INFORMATICS_AWS_LAMBDA_REPO
+        assert assets.docker_assets.source is docker_source
 
-    def test__init__str_source_backward_compat(self):
+    def test__init__str_sources(self):
+        stack = self.get_dummy_stack("test")
+        assets = AIBSInformaticsAssets(
+            stack,
+            "Assets",
+            self.env_base,
+            code_source="git@github.com:org/custom.git",
+            docker_source="ghcr.io/org/repo:v1",
+        )
+        assert isinstance(assets.code_assets.source, GitSource)
+        assert assets.code_assets.source.url == "git@github.com:org/custom.git"
+        assert isinstance(assets.docker_assets.source, ContainerImageSource)
+        assert assets.docker_assets.source.image_uri == "ghcr.io/org/repo:v1"
+
+    def test__init__deprecated_repo_kwarg_sets_both(self):
         stack = self.get_dummy_stack("test")
         repo_url = "git@github.com:org/custom.git"
-        assets = AIBSInformaticsAssets(
-            stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
-        )
-        assert isinstance(assets.code_assets._source, GitSource)
-        assert isinstance(assets.docker_assets._source, GitSource)
-        assert assets.code_assets._source.url == "git@github.com:org/custom.git"
-        assert assets.docker_assets._source.url == "git@github.com:org/custom.git"
+        with pytest.warns(DeprecationWarning, match="aibs_informatics_aws_lambda_repo"):
+            assets = AIBSInformaticsAssets(
+                stack, "Assets", self.env_base, aibs_informatics_aws_lambda_repo=repo_url
+            )
+        assert isinstance(assets.code_assets.source, GitSource)
+        assert isinstance(assets.docker_assets.source, GitSource)
+        assert assets.code_assets.source.url == repo_url
+        assert assets.docker_assets.source.url == repo_url
+
+    def test__init__deprecated_repo_kwarg_with_new_kwarg_raises(self):
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            AIBSInformaticsAssets(
+                stack,
+                "Assets",
+                self.env_base,
+                docker_source="ghcr.io/org/repo:v1",
+                aibs_informatics_aws_lambda_repo="git@github.com:org/custom.git",
+            )

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
@@ -1,0 +1,259 @@
+import pytest
+from pytest import mark, param
+
+from aibs_informatics_cdk_lib.constructs_.assets.source import (
+    ContainerImageSource,
+    GitSource,
+    PackageSource,
+    PackageSourceType,
+)
+
+
+# ---------------------------------------------------------------------------
+# GitSource
+# ---------------------------------------------------------------------------
+
+
+class TestGitSource:
+    def test__version_id__prefers_commit(self):
+        source = GitSource(url="git@github.com:org/repo.git", commit="abc123", tag="v1", branch="main")
+        assert source.version_id() == "abc123"
+
+    def test__version_id__falls_back_to_tag(self):
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.2.3", branch="main")
+        assert source.version_id() == "v1.2.3"
+
+    def test__version_id__falls_back_to_branch(self):
+        source = GitSource(url="git@github.com:org/repo.git", branch="feature-x")
+        assert source.version_id() == "feature-x"
+
+    def test__version_id__defaults_to_HEAD(self):
+        source = GitSource(url="git@github.com:org/repo.git")
+        assert source.version_id() == "HEAD"
+
+    def test__repo_url_with_ref__no_ref(self):
+        source = GitSource(url="git@github.com:org/repo.git")
+        assert source.repo_url_with_ref == "git@github.com:org/repo.git"
+
+    def test__repo_url_with_ref__with_branch(self):
+        source = GitSource(url="git@github.com:org/repo.git", branch="main")
+        assert source.repo_url_with_ref == "git@github.com:org/repo.git#main"
+
+    def test__repo_url_with_ref__with_tag(self):
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        assert source.repo_url_with_ref == "git@github.com:org/repo.git#v1.0.0"
+
+    def test__repo_url_with_ref__with_commit(self):
+        source = GitSource(url="git@github.com:org/repo.git", commit="abc123")
+        assert source.repo_url_with_ref == "git@github.com:org/repo.git#abc123"
+
+    def test__repo_url_with_ref__prefers_commit_over_tag_and_branch(self):
+        source = GitSource(
+            url="git@github.com:org/repo.git", commit="abc123", tag="v1", branch="main"
+        )
+        assert source.repo_url_with_ref == "git@github.com:org/repo.git#abc123"
+
+    def test__source_type(self):
+        source = GitSource(url="git@github.com:org/repo.git")
+        assert source.source_type == "git"
+
+    def test__serialization_roundtrip(self):
+        source = GitSource(url="git@github.com:org/repo.git", branch="main", tag="v1")
+        data = source.model_dump()
+        restored = GitSource.model_validate(data)
+        assert restored == source
+
+
+# ---------------------------------------------------------------------------
+# ContainerImageSource
+# ---------------------------------------------------------------------------
+
+
+class TestContainerImageSource:
+    def test__version_id__prefers_digest(self):
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1", digest="sha256:abc")
+        assert source.version_id() == "sha256:abc"
+
+    def test__version_id__falls_back_to_tag(self):
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1.2.3")
+        assert source.version_id() == "v1.2.3"
+
+    def test__image_uri__with_tag(self):
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1.2.3")
+        assert source.image_uri == "ghcr.io/org/repo:v1.2.3"
+
+    def test__image_uri__with_digest(self):
+        source = ContainerImageSource(image="ghcr.io/org/repo", digest="sha256:abc123")
+        assert source.image_uri == "ghcr.io/org/repo@sha256:abc123"
+
+    def test__image_uri__defaults_to_latest(self):
+        source = ContainerImageSource(image="ghcr.io/org/repo")
+        assert source.image_uri == "ghcr.io/org/repo:latest"
+        assert source.tag == "latest"
+
+    def test__source_type(self):
+        source = ContainerImageSource(image="ghcr.io/org/repo")
+        assert source.source_type == "container"
+
+    def test__serialization_roundtrip(self):
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1", digest="sha256:abc")
+        data = source.model_dump()
+        restored = ContainerImageSource.model_validate(data)
+        assert restored == source
+
+
+# ---------------------------------------------------------------------------
+# PackageSource.from_str
+# ---------------------------------------------------------------------------
+
+
+class TestPackageSourceFromStr:
+    @mark.parametrize(
+        "value, expected_url, expected_branch",
+        [
+            param(
+                "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git",
+                "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git",
+                None,
+                id="ssh no ref",
+            ),
+            param(
+                "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git#main",
+                "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git",
+                "main",
+                id="ssh with branch",
+            ),
+            param(
+                "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git#v1.2.3",
+                "git@github.com:AllenInstitute/aibs-informatics-aws-lambda.git",
+                "v1.2.3",
+                id="ssh with tag ref",
+            ),
+            param(
+                "https://github.com/AllenInstitute/aibs-informatics-aws-lambda.git",
+                "https://github.com/AllenInstitute/aibs-informatics-aws-lambda.git",
+                None,
+                id="https no ref",
+            ),
+            param(
+                "https://github.com/AllenInstitute/aibs-informatics-aws-lambda.git@main",
+                "https://github.com/AllenInstitute/aibs-informatics-aws-lambda.git",
+                "main",
+                id="https with branch",
+            ),
+            param(
+                "ssh://github.com/org/package.git",
+                "ssh://github.com/org/package.git",
+                None,
+                id="ssh protocol url",
+            ),
+        ],
+    )
+    def test__from_str__git_urls(self, value, expected_url, expected_branch):
+        source = PackageSource.from_str(value)
+        assert isinstance(source, GitSource)
+        assert source.url == expected_url
+        assert source.branch == expected_branch
+
+    @mark.parametrize(
+        "value, expected_image, expected_tag, expected_digest",
+        [
+            param(
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:v1.2.3",
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda",
+                "v1.2.3",
+                None,
+                id="ghcr with tag",
+            ),
+            param(
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:latest",
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda",
+                "latest",
+                None,
+                id="ghcr with latest",
+            ),
+            param(
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda",
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda",
+                "latest",
+                None,
+                id="ghcr no tag defaults to latest",
+            ),
+            param(
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:sha-abc1234",
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda",
+                "sha-abc1234",
+                None,
+                id="ghcr with sha tag",
+            ),
+            param(
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890",
+                "ghcr.io/alleninstitute/aibs-informatics-aws-lambda",
+                "latest",
+                "sha256:abcdef1234567890",
+                id="ghcr with digest",
+            ),
+            param(
+                "docker.io/library/python:3.11",
+                "docker.io/library/python",
+                "3.11",
+                None,
+                id="docker hub",
+            ),
+            param(
+                "123456789.dkr.ecr.us-west-2.amazonaws.com/my-repo:v1",
+                "123456789.dkr.ecr.us-west-2.amazonaws.com/my-repo",
+                "v1",
+                None,
+                id="ecr",
+            ),
+        ],
+    )
+    def test__from_str__container_images(self, value, expected_image, expected_tag, expected_digest):
+        source = PackageSource.from_str(value)
+        assert isinstance(source, ContainerImageSource)
+        assert source.image == expected_image
+        assert source.tag == expected_tag
+        assert source.digest == expected_digest
+
+    def test__from_str__invalid_string_raises(self):
+        with pytest.raises(ValueError, match="Cannot parse"):
+            PackageSource.from_str("not-a-valid-source")
+
+    def test__from_str__local_repo(self, tmp_path):
+        """Local git repos should parse as GitSource."""
+        # Initialize a git repo in the temp directory
+        import subprocess
+
+        subprocess.check_call(["git", "init", str(tmp_path)])
+        subprocess.check_call(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=str(tmp_path),
+        )
+
+        source = PackageSource.from_str(str(tmp_path))
+        assert isinstance(source, GitSource)
+        assert source.url == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Discriminated union (PackageSourceType)
+# ---------------------------------------------------------------------------
+
+
+class TestPackageSourceType:
+    def test__discriminated_union__git_source(self):
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(PackageSourceType)
+        result = adapter.validate_python({"source_type": "git", "url": "git@github.com:org/repo.git"})
+        assert isinstance(result, GitSource)
+
+    def test__discriminated_union__container_source(self):
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(PackageSourceType)
+        result = adapter.validate_python(
+            {"source_type": "container", "image": "ghcr.io/org/repo", "tag": "v1"}
+        )
+        assert isinstance(result, ContainerImageSource)

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
@@ -8,7 +8,6 @@ from aibs_informatics_cdk_lib.constructs_.assets.source import (
     PackageSourceType,
 )
 
-
 # ---------------------------------------------------------------------------
 # GitSource
 # ---------------------------------------------------------------------------
@@ -16,7 +15,9 @@ from aibs_informatics_cdk_lib.constructs_.assets.source import (
 
 class TestGitSource:
     def test__version_id__prefers_commit(self):
-        source = GitSource(url="git@github.com:org/repo.git", commit="abc123", tag="v1", branch="main")
+        source = GitSource(
+            url="git@github.com:org/repo.git", commit="abc123", tag="v1", branch="main"
+        )
         assert source.version_id() == "abc123"
 
     def test__version_id__falls_back_to_tag(self):
@@ -209,7 +210,9 @@ class TestPackageSourceFromStr:
             ),
         ],
     )
-    def test__from_str__container_images(self, value, expected_image, expected_tag, expected_digest):
+    def test__from_str__container_images(
+        self, value, expected_image, expected_tag, expected_digest
+    ):
         source = PackageSource.from_str(value)
         assert isinstance(source, ContainerImageSource)
         assert source.image == expected_image
@@ -246,7 +249,9 @@ class TestPackageSourceType:
         from pydantic import TypeAdapter
 
         adapter = TypeAdapter(PackageSourceType)
-        result = adapter.validate_python({"source_type": "git", "url": "git@github.com:org/repo.git"})
+        result = adapter.validate_python(
+            {"source_type": "git", "url": "git@github.com:org/repo.git"}
+        )
         assert isinstance(result, GitSource)
 
     def test__discriminated_union__container_source(self):

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
@@ -230,6 +230,14 @@ class TestPackageSourceFromStr:
 
         subprocess.check_call(["git", "init", str(tmp_path)])
         subprocess.check_call(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=str(tmp_path),
+        )
+        subprocess.check_call(
+            ["git", "config", "user.name", "Test"],
+            cwd=str(tmp_path),
+        )
+        subprocess.check_call(
             ["git", "commit", "--allow-empty", "-m", "init"],
             cwd=str(tmp_path),
         )

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
@@ -300,6 +300,10 @@ class TestPackageSourceFromStr:
         import subprocess
 
         subprocess.check_call(["git", "init", str(tmp_path)])
+        # Set identity on the temp repo so `git commit` works on runners without a
+        # global git config (CI), rather than only on developer machines.
+        subprocess.check_call(["git", "config", "user.email", "test@test.com"], cwd=str(tmp_path))
+        subprocess.check_call(["git", "config", "user.name", "Test"], cwd=str(tmp_path))
         subprocess.check_call(
             ["git", "commit", "--allow-empty", "-m", "init"],
             cwd=str(tmp_path),

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
@@ -8,7 +8,6 @@ from aibs_informatics_cdk_lib.constructs_.assets.source import (
     PackageSourceType,
 )
 
-
 # ---------------------------------------------------------------------------
 # GitSource
 # ---------------------------------------------------------------------------
@@ -16,7 +15,9 @@ from aibs_informatics_cdk_lib.constructs_.assets.source import (
 
 class TestGitSource:
     def test__version_id__prefers_commit(self):
-        source = GitSource(url="git@github.com:org/repo.git", commit="abc123", tag="v1", branch="main")
+        source = GitSource(
+            url="git@github.com:org/repo.git", commit="abc123", tag="v1", branch="main"
+        )
         assert source.version_id() == "abc123"
 
     def test__version_id__falls_back_to_tag(self):
@@ -209,12 +210,85 @@ class TestPackageSourceFromStr:
             ),
         ],
     )
-    def test__from_str__container_images(self, value, expected_image, expected_tag, expected_digest):
+    def test__from_str__container_images(
+        self, value, expected_image, expected_tag, expected_digest
+    ):
         source = PackageSource.from_str(value)
         assert isinstance(source, ContainerImageSource)
         assert source.image == expected_image
         assert source.tag == expected_tag
         assert source.digest == expected_digest
+
+    @mark.parametrize(
+        "value, expected_branch, expected_tag, expected_commit, expected_version_id",
+        [
+            param(
+                "git@github.com:org/repo.git#refs/heads/main",
+                "main",
+                None,
+                None,
+                "main",
+                id="refs/heads populates branch",
+            ),
+            param(
+                "git@github.com:org/repo.git#refs/tags/v1.2.3",
+                None,
+                "v1.2.3",
+                None,
+                "v1.2.3",
+                id="refs/tags populates tag",
+            ),
+            param(
+                "https://github.com/org/repo/releases/tag/v1.2.3",
+                None,
+                "v1.2.3",
+                None,
+                "v1.2.3",
+                id="releases/tag populates tag",
+            ),
+            param(
+                "https://github.com/org/repo/commit/abc1234",
+                None,
+                None,
+                "abc1234",
+                "abc1234",
+                id="commit path populates commit",
+            ),
+            param(
+                "git@github.com:org/repo.git#abc1234",
+                None,
+                None,
+                "abc1234",
+                "abc1234",
+                id="bare sha populates commit",
+            ),
+            param(
+                "git@github.com:org/repo.git#v1.2.3",
+                "v1.2.3",
+                None,
+                None,
+                "v1.2.3",
+                id="ambiguous ref populates branch",
+            ),
+            param(
+                "git@github.com:org/repo.git",
+                None,
+                None,
+                None,
+                "HEAD",
+                id="no ref",
+            ),
+        ],
+    )
+    def test__from_str__populates_ref_by_kind(
+        self, value, expected_branch, expected_tag, expected_commit, expected_version_id
+    ):
+        source = PackageSource.from_str(value)
+        assert isinstance(source, GitSource)
+        assert source.branch == expected_branch
+        assert source.tag == expected_tag
+        assert source.commit == expected_commit
+        assert source.version_id() == expected_version_id
 
     def test__from_str__invalid_string_raises(self):
         with pytest.raises(ValueError, match="Cannot parse"):
@@ -246,7 +320,9 @@ class TestPackageSourceType:
         from pydantic import TypeAdapter
 
         adapter = TypeAdapter(PackageSourceType)
-        result = adapter.validate_python({"source_type": "git", "url": "git@github.com:org/repo.git"})
+        result = adapter.validate_python(
+            {"source_type": "git", "url": "git@github.com:org/repo.git"}
+        )
         assert isinstance(result, GitSource)
 
     def test__discriminated_union__container_source(self):

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ dependencies = [
     { name = "aibs-informatics-core" },
     { name = "aws-cdk-lib" },
     { name = "constructs" },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -68,6 +69,7 @@ requires-dist = [
     { name = "aibs-informatics-core", specifier = ">=1.0.1,<2" },
     { name = "aws-cdk-lib", specifier = "~=2.96" },
     { name = "constructs", specifier = "~=10.0" },
+    { name = "pydantic", specifier = "~=2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -672,6 +674,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
**Stack 1 of 3** — base `main`. Part of [DT-9926](https://alleninstitute.atlassian.net/browse/DT-9926).

| PR | Branch | Contents |
|---|---|---|
| **#57 (this)** | `feature/improve-docker-assets` | Source model, git ref handling |
| next | `feature/docker-asset-construct` | `DockerAsset` construct, fragment refactor, ADRs |
| next | `feature/ecr-mirroring` | Opt-in ECR mirroring + digest pinning ([DT-9928](https://alleninstitute.atlassian.net/browse/DT-9928)) |

## What and why

Asset constructs accepted only a git repo URL string, so CDK had to clone and build `aibs-informatics-aws-lambda` on every deploy, and pinning a version meant freezing a ref into a module constant — `gcs-infra` currently hard-codes `...aibs-informatics-aws-lambda.git/tree/hotfix/add-env-var-to-context-manager`. That package now publishes to GHCR, so a source may also be a pre-built container image.

## Changes

- `PackageSource` / `GitSource` / `ContainerImageSource` discriminated union, with `from_str()` parsing git URLs, local repo paths, and container image refs.
- `aibs_informatics_aws_lambda_repo` → `aibs_informatics_aws_lambda_source`, old name kept as a deprecated keyword alias.
- `AIBSInformaticsAssets` splits into `code_source` (typed `GitSource | str | None`) and `docker_source`. Code assets require a checkout, so a container image is now rejected statically rather than at property access.
- `GitUrl` classifies ref kind where it is syntactically knowable: `refs/heads/…` → branch, `refs/tags/…` and `/releases/tag/…` → tag, `/commit/<sha>` and bare 7–40 hex → commit. The last two previously did not match at all. Ambiguous refs (`#v1.2.3`, `/tree/main`) fall through to branch — `/tree/` is GitHub's segment for branches, tags *and* SHAs, so no regex can classify it, and branch vs tag makes no behavioural difference (`git ls-remote --branch v1.0.0` returns `refs/tags/v1.0.0`).
- **Bug fix:** `GitSource(commit=...)` produced `git clone --branch <sha>`, which fails — `--branch` takes branch and tag names only. Now clones then fetches and checks out the SHA. `get_commit_hash_from_url` also returned `""` for an unresolvable ref instead of raising, which fed garbage into `construct_repo_path`.
- `AIBS_INFORMATICS_AWS_LAMBDA_REPO` returned the *default* git URL when the source was a container image. It now returns `None`, with a `DeprecationWarning`.
- `pydantic` declared explicitly; it was imported but only present transitively.


## Verification

`196 passed` (153 before this branch), `ruff check` clean, `ruff format --check` clean. `mypy` clean on the touched files when checked explicitly, bypassing the broken exclude.

Backward compatible: five downstream repos consume these constructs and none need edits.

[DT-9926]: https://alleninstitute.atlassian.net/browse/DT-9926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-9928]: https://alleninstitute.atlassian.net/browse/DT-9928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ