### PR TITLE
Enhance the CI/CD release-PR creation flow with auto-generated release notes, an optional LLM summary, and per-service customization hooks

### DIFF
--- a/src/aibs_informatics_cdk_lib/cicd/pipeline/base.py
+++ b/src/aibs_informatics_cdk_lib/cicd/pipeline/base.py
@@ -1,5 +1,6 @@
 import base64
 import functools
+import json
 import logging
 from abc import abstractmethod
 from collections.abc import Callable, Mapping, Sequence
@@ -9,7 +10,7 @@ from typing import Generic, Optional, TypeVar, cast
 
 import aws_cdk as cdk
 import constructs
-from aibs_informatics_core.env import EnvBase
+from aibs_informatics_core.env import EnvBase, EnvType
 from aws_cdk import aws_codepipeline as aws_codepipeline
 from aws_cdk import aws_codepipeline_actions, pipelines
 from aws_cdk import aws_codestarnotifications as codestarnotifications
@@ -269,6 +270,58 @@ class BasePipelineStack(EnvBaseStack, Generic[STAGE_CONFIG, GLOBAL_CONFIG]):
                 promotion_target_env_type
             ).pipeline
             assert promotion_target_pipeline_config is not None
+
+            checklist_items = self.release_checklists.get(promotion_target_env_type, [])
+            extra_sections = self.release_extra_sections.get(promotion_target_env_type, {})
+            llm_summary_enabled = self.release_notes_llm_summary
+            reviewers = self.release_reviewers.get(
+                promotion_target_env_type, self.default_release_reviewers
+            )
+
+            release_env_variables = {
+                "CICD_RELEASE_REVIEWER": ",".join(reviewers),
+                "CICD_RELEASE_SOURCE_ENV_TYPE": source_env_type,
+                "CICD_RELEASE_TARGET_ENV_TYPE": promotion_target_env_type,
+                "CICD_RELEASE_TARGET_BRANCH": promotion_target_pipeline_config.source.branch,
+                "CICD_RELEASE_REPOSITORY": pipeline_config.source.repository,
+                "CICD_RELEASE_CHECKLIST": "\n".join(checklist_items),
+                "CICD_RELEASE_EXTRA_SECTIONS_JSON": json.dumps(dict(extra_sections)),
+                "CICD_RELEASE_LLM_SUMMARY": "true" if llm_summary_enabled else "false",
+            }
+            if llm_summary_enabled:
+                release_env_variables["CICD_RELEASE_LLM_MODEL_ID"] = self.release_llm_model_id
+
+            release_role_policy_statements = [
+                CODE_BUILD_IAM_POLICY,
+                self.get_policy_with_secrets(self.pipeline_config.source.oauth_secret_name),
+            ]
+            if llm_summary_enabled:
+                # Cross-region inference profiles invoke under-the-hood foundation
+                # models in adjacent regions, so the policy needs both resource
+                # patterns. Scoped to a wildcard model id to keep this simple --
+                # the model id itself is set in the build environment, not granted.
+                release_role_policy_statements.append(
+                    iam.PolicyStatement(
+                        effect=iam.Effect.ALLOW,
+                        actions=["bedrock:InvokeModel"],
+                        resources=[
+                            build_arn(
+                                service="bedrock",
+                                resource_type="inference-profile",
+                                resource_delim="/",
+                                resource_id="*",
+                            ),
+                            build_arn(
+                                service="bedrock",
+                                resource_type="foundation-model",
+                                resource_delim="/",
+                                resource_id="*",
+                                account="",
+                            ),
+                        ],
+                    )
+                )
+
             create_pull_request_step = pipelines.CodeBuildStep(
                 "CreateReleasePullRequest",
                 input=self.get_pipeline_source(pipeline_config.source),
@@ -280,12 +333,7 @@ class BasePipelineStack(EnvBaseStack, Generic[STAGE_CONFIG, GLOBAL_CONFIG]):
                     {
                         "env": {
                             "shell": "bash",
-                            "variables": {
-                                "CICD_RELEASE_REVIEWER": "AllenInstitute/marmot",
-                                "CICD_RELEASE_SOURCE_ENV_TYPE": source_env_type,
-                                "CICD_RELEASE_TARGET_ENV_TYPE": promotion_target_env_type,
-                                "CICD_RELEASE_TARGET_BRANCH": promotion_target_pipeline_config.source.branch,  # noqa: E501
-                            },
+                            "variables": release_env_variables,
                             # https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec.env.secrets-manager
                             "secrets-manager": {
                                 "GITHUB_TOKEN": pipeline_config.source.oauth_secret_name,
@@ -369,10 +417,7 @@ class BasePipelineStack(EnvBaseStack, Generic[STAGE_CONFIG, GLOBAL_CONFIG]):
                     # Run the release script
                     "bash $RELEASE_SCRIPT_PATH",
                 ],
-                role_policy_statements=[
-                    CODE_BUILD_IAM_POLICY,
-                    self.get_policy_with_secrets(self.pipeline_config.source.oauth_secret_name),
-                ],
+                role_policy_statements=release_role_policy_statements,
             )
             # Add dependencies to all other "post" steps
             if promote_wave.post:
@@ -454,6 +499,80 @@ class BasePipelineStack(EnvBaseStack, Generic[STAGE_CONFIG, GLOBAL_CONFIG]):
     @property
     def custom_codebuild_environment_variables(self) -> Mapping[str, BuildEnvironmentVariable]:
         return {}
+
+    @property
+    def default_release_reviewers(self) -> Sequence[str]:
+        """Reviewers requested on the release PR when no per-target override
+        is provided via ``release_reviewers``.
+
+        Override in a subclass to change the team-wide default.
+        """
+        return ["AllenInstitute/aibs-data-solution"]
+
+    @property
+    def release_reviewers(self) -> Mapping[EnvType, Sequence[str]]:
+        """Reviewers requested on the release PR, keyed by promotion target.
+
+        Each value is a list of GitHub user logins or ``org/team`` slugs that
+        will be passed to ``gh pr create --reviewer`` (comma-joined).
+
+        Override in a subclass for service-specific reviewers, e.g.:
+
+            return {
+                EnvType.PROD: ["AllenInstitute/oncall", "AllenInstitute/leads"],
+            }
+
+        When the mapping has no entry for the active promotion target,
+        ``default_release_reviewers`` is used.
+        """
+        return {}
+
+    @property
+    def release_checklists(self) -> Mapping[EnvType, Sequence[str]]:
+        """Checklist items rendered into the release PR body, keyed by promotion target.
+
+        Override in a subclass to add per-target checklist items, e.g.:
+
+            return {
+                EnvType.PROD: [
+                    "Notified on-call",
+                    "Confirmed rollback plan",
+                ],
+            }
+
+        When the mapping has no entry for the active promotion target, the
+        Checklist section is omitted from the PR body entirely.
+        """
+        return {}
+
+    @property
+    def release_extra_sections(self) -> Mapping[EnvType, Mapping[str, str]]:
+        """Extra markdown sections appended to the release PR body, keyed by
+        promotion target. Inner mapping is heading -> markdown body.
+
+        Override in a subclass for service-specific sections (schema migrations,
+        feature-flag references, dashboards, etc.).
+        """
+        return {}
+
+    @property
+    def release_notes_llm_summary(self) -> bool:
+        """If True, prepend a Bedrock-generated narrative summary to the release
+        PR body. Requires the CodeBuild role to have bedrock:InvokeModel access
+        (added automatically when this is True).
+        """
+        return False
+
+    @property
+    def release_llm_model_id(self) -> str:
+        """Bedrock model id used when ``release_notes_llm_summary`` is enabled.
+
+        Defaults to Claude Haiku 4.5 -- plenty capable for a 2-3 sentence
+        release-note summary at a fraction of the cost of Sonnet/Opus.
+        Override to use Sonnet 4.6 / Opus 4.8 or to pin to a specific
+        cross-region inference profile (e.g. ``us.anthropic.claude-haiku-4-5``).
+        """
+        return "anthropic.claude-haiku-4-5"
 
     @property
     def source_cache(self) -> dict[str, pipelines.CodePipelineSource]:

--- a/src/aibs_informatics_cdk_lib/cicd/pipeline/base.py
+++ b/src/aibs_informatics_cdk_lib/cicd/pipeline/base.py
@@ -569,10 +569,17 @@ class BasePipelineStack(EnvBaseStack, Generic[STAGE_CONFIG, GLOBAL_CONFIG]):
 
         Defaults to Claude Haiku 4.5 -- plenty capable for a 2-3 sentence
         release-note summary at a fraction of the cost of Sonnet/Opus.
-        Override to use Sonnet 4.6 / Opus 4.8 or to pin to a specific
-        cross-region inference profile (e.g. ``us.anthropic.claude-haiku-4-5``).
+
+        This is a cross-region inference profile id (note the ``us.`` prefix).
+        Bedrock requires an inference profile -- not the bare foundation-model
+        id ``anthropic.claude-haiku-4-5-20251001-v1:0`` -- for on-demand
+        ``invoke-model`` of the newer Claude models; the foundation-model id
+        returns a ValidationException. Verify the exact id for your region with
+        ``aws bedrock list-inference-profiles --region <region>``.
+
+        Override to use Sonnet 4.6 / Opus 4.8 or to pin a different region group.
         """
-        return "anthropic.claude-haiku-4-5-20251001-v1:0"
+        return "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 
     @property
     def source_cache(self) -> dict[str, pipelines.CodePipelineSource]:

--- a/src/aibs_informatics_cdk_lib/cicd/pipeline/base.py
+++ b/src/aibs_informatics_cdk_lib/cicd/pipeline/base.py
@@ -507,7 +507,7 @@ class BasePipelineStack(EnvBaseStack, Generic[STAGE_CONFIG, GLOBAL_CONFIG]):
 
         Override in a subclass to change the team-wide default.
         """
-        return ["AllenInstitute/aibs-data-solution"]
+        return ["AllenInstitute/aibs-data-solutions"]
 
     @property
     def release_reviewers(self) -> Mapping[EnvType, Sequence[str]]:
@@ -572,7 +572,7 @@ class BasePipelineStack(EnvBaseStack, Generic[STAGE_CONFIG, GLOBAL_CONFIG]):
         Override to use Sonnet 4.6 / Opus 4.8 or to pin to a specific
         cross-region inference profile (e.g. ``us.anthropic.claude-haiku-4-5``).
         """
-        return "anthropic.claude-haiku-4-5"
+        return "anthropic.claude-haiku-4-5-20251001-v1:0"
 
     @property
     def source_cache(self) -> dict[str, pipelines.CodePipelineSource]:

--- a/src/aibs_informatics_cdk_lib/cicd/pipeline/scripts/cicd-release.sh
+++ b/src/aibs_informatics_cdk_lib/cicd/pipeline/scripts/cicd-release.sh
@@ -233,7 +233,7 @@ render_llm_summary() {
         max_tokens: 500,
         messages: [{
             role: "user",
-            content: ("Summarize this software release in 2-3 sentences for a deployment PR description. Focus on themes and user-facing impact. Do not restate the bullet list verbatim. Release contents:\n\n" + $notes)
+            content: ("Summarize this software release in 1-2 paragraphs for a deployment PR description. Focus on themes and user-facing impact. Do not restate the bullet list verbatim. Release contents:\n\n" + $notes)
         }]
     }' > "$request_file"
 

--- a/src/aibs_informatics_cdk_lib/cicd/pipeline/scripts/cicd-release.sh
+++ b/src/aibs_informatics_cdk_lib/cicd/pipeline/scripts/cicd-release.sh
@@ -3,19 +3,32 @@
 #################################################################
 #                   CI/CD Release Script
 #  Description:
-#   Purpose of this script is to facilitate submit Pull Requests 
-#   from a source branch/commit to a destination branch. 
-#    
+#   Purpose of this script is to facilitate submit Pull Requests
+#   from a source branch/commit to a destination branch.
+#
 # Input Environment Variables:
-#   
+#
 #   CICD_RELEASE_SOURCE_ENV_TYPE:
 #       Environment Type of source branch
-#   CICD_RELEASE_TARGET_ENV_TYPE: 
+#   CICD_RELEASE_TARGET_ENV_TYPE:
 #       Environment Type of source branch
 #   CICD_RELEASE_TARGET_BRANCH:
 #       Target branch to submit pull request into
 #   CICD_RELEASE_REVIEWER:
 #       Reviewers for the PR
+#   CICD_RELEASE_REPOSITORY:
+#       Source repository in owner/repo format (used for GitHub API calls)
+#   CICD_RELEASE_CHECKLIST:
+#       Newline-separated checklist items (optional). When empty, no
+#       Checklist section is rendered.
+#   CICD_RELEASE_EXTRA_SECTIONS_JSON:
+#       JSON object mapping section-heading -> markdown-body for extra
+#       PR-body sections (optional).
+#   CICD_RELEASE_LLM_SUMMARY:
+#       "true"/"false" -- when true, prepend a Bedrock-generated narrative
+#       summary above the bullet list.
+#   CICD_RELEASE_LLM_MODEL_ID:
+#       Bedrock model ID used for the LLM summary.
 
 ###################################
 
@@ -30,6 +43,9 @@ echo "==> CICD_RELEASE_SOURCE_COMMIT = $CICD_RELEASE_SOURCE_COMMIT"
 echo "==> CICD_RELEASE_CANDIDATE_BRANCH = $CICD_RELEASE_CANDIDATE_BRANCH"
 echo "==> CICD_RELEASE_TARGET_BRANCH = $CICD_RELEASE_TARGET_BRANCH"
 echo "==> CICD_RELEASE_REVIEWER = $CICD_RELEASE_REVIEWER"
+echo "==> CICD_RELEASE_REPOSITORY = $CICD_RELEASE_REPOSITORY"
+echo "==> CICD_RELEASE_LLM_SUMMARY = $CICD_RELEASE_LLM_SUMMARY"
+echo "==> CICD_RELEASE_LLM_MODEL_ID = $CICD_RELEASE_LLM_MODEL_ID"
 
 export CICD_RELEASE_GIT_MESSAGE="$(git log -1 --pretty=%B)"
 export CICD_RELEASE_GIT_AUTHOR="$(git log -1 --pretty=%an)"
@@ -42,7 +58,7 @@ echo "==> CICD_RELEASE_GIT_AUTHOR = $CICD_RELEASE_GIT_AUTHOR"
 echo "==> CICD_RELEASE_GIT_AUTHOR_EMAIL = $CICD_RELEASE_GIT_AUTHOR_EMAIL"
 echo "==> CICD_RELEASE_GIT_COMMIT = $CICD_RELEASE_GIT_COMMIT"
 echo "==> CICD_RELEASE_GIT_SHORT_COMMIT = $CICD_RELEASE_GIT_SHORT_COMMIT"
-echo 
+echo
 
 
 echo "Verify gh command is on PATH"
@@ -52,7 +68,7 @@ if ! command -v gh &> /dev/null; then
     exit 1
 fi
 
-echo 
+echo
 echo "==> Promoting commits up to $CICD_RELEASE_GIT_SHORT_COMMIT to release candidate branch."
 echo "==> Release candidate branch: $CICD_RELEASE_CANDIDATE_BRANCH"
 
@@ -67,7 +83,12 @@ CICD_RELEASE_PR_TITLE="Release $CICD_RELEASE_SOURCE_ENV_TYPE -> $CICD_RELEASE_TA
 CICD_RELEASE_PR_MESSAGE_FILE=$(mktemp)
 
 
-cat <<EOF > $CICD_RELEASE_PR_MESSAGE_FILE
+###################################
+# PR body rendering helpers
+###################################
+
+render_header() {
+    cat <<EOF
 # Release
 ## Release Summary
 | Release Attribute | Value |
@@ -76,17 +97,213 @@ cat <<EOF > $CICD_RELEASE_PR_MESSAGE_FILE
 | Source Branch | $CICD_RELEASE_CANDIDATE_BRANCH ($CICD_RELEASE_GIT_SHORT_COMMIT) |
 | Date          | $(date '+%Y-%m-%d %H:%M:%S') |
 
-## Release Notes
-
-This release includes changes up to $CICD_RELEASE_GIT_SHORT_COMMIT. This includes the following:
-- (fill me please)
-- (fill me please)
-- (fill me please)
-
-## Checklist
-- [ ] All of GCS works impeccably
-
 EOF
+}
+
+render_release_notes_body() {
+    local base="$CICD_RELEASE_TARGET_BRANCH"
+    local head="$CICD_RELEASE_SOURCE_COMMIT"
+
+    if [[ -z "$CICD_RELEASE_REPOSITORY" ]]; then
+        echo "_Repository not configured; falling back to git log:_"
+        echo
+        git log "origin/$base..$head" --pretty=format:"- %s (%h) -- @%an" --no-merges 2>/dev/null \
+            || echo "_(no commits found)_"
+        return
+    fi
+
+    local compare_json
+    compare_json=$(gh api "repos/$CICD_RELEASE_REPOSITORY/compare/$base...$head" 2>/dev/null)
+
+    if [[ -z "$compare_json" ]]; then
+        echo "_GitHub compare API unavailable; falling back to git log:_"
+        echo
+        git log "origin/$base..$head" --pretty=format:"- %s (%h) -- @%an" --no-merges 2>/dev/null \
+            || echo "_(no commits found)_"
+        return
+    fi
+
+    local commit_count
+    commit_count=$(jq '.commits | length' <<< "$compare_json")
+
+    if [[ "$commit_count" == "0" ]]; then
+        echo "_No new commits in this release._"
+        return
+    fi
+
+    if [[ "$commit_count" -ge 250 ]]; then
+        echo "_Release exceeds GitHub compare API limit (250 commits); falling back to git log:_"
+        echo
+        git log "origin/$base..$head" --pretty=format:"- %s (%h) -- @%an" --no-merges
+        return
+    fi
+
+    local breaking="" features="" fixes="" other="" direct=""
+    local seen_prs=" "
+    local sha
+
+    while IFS= read -r sha; do
+        local pulls_json
+        pulls_json=$(gh api "repos/$CICD_RELEASE_REPOSITORY/commits/$sha/pulls" 2>/dev/null)
+
+        if [[ -z "$pulls_json" || "$(jq 'length' <<< "$pulls_json" 2>/dev/null)" == "0" ]]; then
+            local subj short_sha
+            subj=$(jq -r --arg s "$sha" '.commits[] | select(.sha == $s) | .commit.message' <<< "$compare_json" | head -n1)
+            short_sha=${sha:0:7}
+            direct+="- ${subj:-$sha} ($short_sha)"$'\n'
+            continue
+        fi
+
+        local pr_number pr_title pr_user pr_labels entry
+        pr_number=$(jq -r '.[0].number' <<< "$pulls_json")
+
+        if [[ "$seen_prs" == *" $pr_number "* ]]; then
+            continue
+        fi
+        seen_prs+="$pr_number "
+
+        pr_title=$(jq -r '.[0].title' <<< "$pulls_json")
+        pr_user=$(jq -r '.[0].user.login' <<< "$pulls_json")
+        pr_labels=$(jq -r '.[0].labels[]?.name // empty' <<< "$pulls_json" | tr '\n' ' ')
+
+        entry="- #$pr_number $pr_title (@$pr_user)"$'\n'
+
+        if echo "$pr_labels" | grep -qiE '(^| )(breaking|breaking-change)( |$)'; then
+            breaking+="$entry"
+        elif echo "$pr_labels" | grep -qiE '(^| )(feat|feature|enhancement)( |$)'; then
+            features+="$entry"
+        elif echo "$pr_labels" | grep -qiE '(^| )(fix|bug|bugfix)( |$)'; then
+            fixes+="$entry"
+        else
+            other+="$entry"
+        fi
+    done < <(jq -r '.commits[].sha' <<< "$compare_json")
+
+    if [[ -n "$breaking" ]]; then
+        echo "### Breaking Changes"
+        echo
+        printf '%s' "$breaking"
+        echo
+    fi
+    if [[ -n "$features" ]]; then
+        echo "### Features"
+        echo
+        printf '%s' "$features"
+        echo
+    fi
+    if [[ -n "$fixes" ]]; then
+        echo "### Fixes"
+        echo
+        printf '%s' "$fixes"
+        echo
+    fi
+    if [[ -n "$other" ]]; then
+        echo "### Other Changes"
+        echo
+        printf '%s' "$other"
+        echo
+    fi
+    if [[ -n "$direct" ]]; then
+        echo "### Direct Commits"
+        echo
+        printf '%s' "$direct"
+        echo
+    fi
+}
+
+render_llm_summary() {
+    [[ "$CICD_RELEASE_LLM_SUMMARY" == "true" ]] || return 0
+
+    if ! command -v aws &> /dev/null; then
+        echo "==! aws CLI not found; skipping LLM summary." >&2
+        return 0
+    fi
+
+    local notes_body="$1"
+    [[ -n "$notes_body" ]] || return 0
+
+    local model_id="${CICD_RELEASE_LLM_MODEL_ID:-anthropic.claude-haiku-4-5}"
+
+    local request_file response_file
+    request_file=$(mktemp)
+    response_file=$(mktemp)
+
+    jq -n --arg notes "$notes_body" '{
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 500,
+        messages: [{
+            role: "user",
+            content: ("Summarize this software release in 2-3 sentences for a deployment PR description. Focus on themes and user-facing impact. Do not restate the bullet list verbatim. Release contents:\n\n" + $notes)
+        }]
+    }' > "$request_file"
+
+    if aws bedrock-runtime invoke-model \
+        --model-id "$model_id" \
+        --body "fileb://$request_file" \
+        --content-type application/json \
+        "$response_file" &> /dev/null; then
+        local summary
+        summary=$(jq -r '.content[0].text // empty' "$response_file" 2>/dev/null)
+        if [[ -n "$summary" ]]; then
+            echo "## Summary"
+            echo
+            echo "$summary"
+            echo
+        fi
+    else
+        echo "==! Bedrock invoke failed; skipping LLM summary." >&2
+    fi
+
+    rm -f "$request_file" "$response_file"
+}
+
+render_checklist() {
+    [[ -n "$CICD_RELEASE_CHECKLIST" ]] || return 0
+
+    echo "## Checklist"
+    echo
+    while IFS= read -r item; do
+        [[ -n "$item" ]] && echo "- [ ] $item"
+    done <<< "$CICD_RELEASE_CHECKLIST"
+    echo
+}
+
+render_extra_sections() {
+    [[ -n "$CICD_RELEASE_EXTRA_SECTIONS_JSON" ]] || return 0
+    [[ "$CICD_RELEASE_EXTRA_SECTIONS_JSON" == "{}" ]] && return 0
+
+    local headings
+    headings=$(jq -r 'keys[]' <<< "$CICD_RELEASE_EXTRA_SECTIONS_JSON" 2>/dev/null) || return 0
+
+    while IFS= read -r heading; do
+        [[ -n "$heading" ]] || continue
+        local body
+        body=$(jq -r --arg h "$heading" '.[$h]' <<< "$CICD_RELEASE_EXTRA_SECTIONS_JSON")
+        echo "## $heading"
+        echo
+        echo "$body"
+        echo
+    done <<< "$headings"
+}
+
+###################################
+# Compose PR body
+###################################
+
+RELEASE_NOTES_BODY=$(render_release_notes_body)
+
+{
+    render_header
+    render_llm_summary "$RELEASE_NOTES_BODY"
+    echo "## Release Notes"
+    echo
+    echo "This release includes changes up to $CICD_RELEASE_GIT_SHORT_COMMIT."
+    echo
+    echo "$RELEASE_NOTES_BODY"
+    echo
+    render_checklist
+    render_extra_sections
+} > "$CICD_RELEASE_PR_MESSAGE_FILE"
 
 
 echo "==> Checking for open Pull Requests..."
@@ -96,11 +313,11 @@ if [[ ! -z $EXISTING_PR_NUMBER ]]; then
     echo "==> Pull Request already exists ($EXISTING_PR_NUMBER). Updating..."
 
     # Update the PR message
-    echo "" | cat >> $CICD_RELEASE_PR_MESSAGE_FILE 
-    echo "---" | cat >> $CICD_RELEASE_PR_MESSAGE_FILE 
-    echo "# Previous Revisions" | cat >> $CICD_RELEASE_PR_MESSAGE_FILE
-    echo "---" | cat >> $CICD_RELEASE_PR_MESSAGE_FILE
-    echo "" | cat >> $CICD_RELEASE_PR_MESSAGE_FILE
+    echo "" >> $CICD_RELEASE_PR_MESSAGE_FILE
+    echo "---" >> $CICD_RELEASE_PR_MESSAGE_FILE
+    echo "# Previous Revisions" >> $CICD_RELEASE_PR_MESSAGE_FILE
+    echo "---" >> $CICD_RELEASE_PR_MESSAGE_FILE
+    echo "" >> $CICD_RELEASE_PR_MESSAGE_FILE
     gh pr view --json body | jq -r '.body' >> $CICD_RELEASE_PR_MESSAGE_FILE
 
     gh pr edit $EXISTING_PR_NUMBER \

--- a/src/aibs_informatics_cdk_lib/cicd/pipeline/scripts/cicd-release.sh
+++ b/src/aibs_informatics_cdk_lib/cicd/pipeline/scripts/cicd-release.sh
@@ -80,6 +80,11 @@ git push --set-upstream --force origin $CICD_RELEASE_CANDIDATE_BRANCH
 CICD_RELEASE_DATE=$(date '+%Y-%m-%d')
 CICD_RELEASE_PR_TITLE="Release $CICD_RELEASE_SOURCE_ENV_TYPE -> $CICD_RELEASE_TARGET_ENV_TYPE ($CICD_RELEASE_DATE)"
 
+# Release tags chain each promotion to the next: this run's tag becomes the
+# `previous_tag_name` for the next promotion's generated release notes.
+CICD_RELEASE_TAG_NAMESPACE="cicd-release/$CICD_RELEASE_TARGET_BRANCH"
+CICD_RELEASE_NEW_TAG="$CICD_RELEASE_TAG_NAMESPACE/$CICD_RELEASE_DATE-$CICD_RELEASE_GIT_SHORT_COMMIT"
+
 CICD_RELEASE_PR_MESSAGE_FILE=$(mktemp)
 
 
@@ -100,115 +105,90 @@ render_header() {
 EOF
 }
 
-render_release_notes_body() {
-    local base="$CICD_RELEASE_TARGET_BRANCH"
-    local head="$CICD_RELEASE_SOURCE_COMMIT"
+# Resolve the previous release tag: the most recent tag in our release-tag
+# namespace that sits on the CURRENT SOURCE LINE (i.e. is an ancestor of the
+# commit being promoted).
+#
+# We anchor on the source commit -- NOT the target branch -- so the chain
+# survives every merge strategy. The promotion PR merges source -> target;
+# squash/rebase merges rewrite commits on the TARGET side, but the source
+# branch is never rewritten and only moves forward, so a tag created at a
+# prior source tip stays an ancestor of the current source tip. `--merged`
+# scopes selection to this source line, so tags from a different promotion lane
+# (a different source branch sharing this target's tag namespace) are excluded.
+#
+# `grep -vxF` drops the tag this run is about to create, in case a same-day
+# re-run of the same commit already pushed it. Prints the tag name, or empty
+# when none exists (e.g. the first promotion into this target).
+resolve_previous_release_tag() {
+    git tag --list "$CICD_RELEASE_TAG_NAMESPACE/*" \
+        --merged "$CICD_RELEASE_SOURCE_COMMIT" \
+        --sort=-creatordate 2>/dev/null \
+        | grep -vxF "$CICD_RELEASE_NEW_TAG" \
+        | head -n1
+}
 
+# Fallback used whenever GitHub's generate-notes endpoint can't be reached
+# (repo unconfigured, API error, etc.). Range is the previous release tag (or
+# the target branch tip on the first release) up to the promoted commit.
+render_release_notes_git_log() {
+    local since="$1"
+    local range
+    if [[ -n "$since" ]]; then
+        range="$since..$CICD_RELEASE_SOURCE_COMMIT"
+    else
+        range="origin/$CICD_RELEASE_TARGET_BRANCH..$CICD_RELEASE_SOURCE_COMMIT"
+    fi
+    git log "$range" --pretty=format:"- %s (%h) -- @%an" --no-merges 2>/dev/null \
+        || echo "_(no commits found)_"
+}
+
+render_release_notes_body() {
     if [[ -z "$CICD_RELEASE_REPOSITORY" ]]; then
         echo "_Repository not configured; falling back to git log:_"
         echo
-        git log "origin/$base..$head" --pretty=format:"- %s (%h) -- @%an" --no-merges 2>/dev/null \
-            || echo "_(no commits found)_"
+        render_release_notes_git_log ""
         return
     fi
 
-    local compare_json
-    compare_json=$(gh api "repos/$CICD_RELEASE_REPOSITORY/compare/$base...$head" 2>/dev/null)
+    local previous_tag
+    previous_tag=$(resolve_previous_release_tag)
 
-    if [[ -z "$compare_json" ]]; then
-        echo "_GitHub compare API unavailable; falling back to git log:_"
+    # GitHub's generate-notes builds categorized, PR-aware notes server-side in
+    # a single call -- buckets and labels are controlled per-repo via
+    # .github/release.yml. The change range is previous_tag -> source commit.
+    # When there is no previous tag (first release into this branch), omitting
+    # previous_tag_name lets GitHub auto-select; we instead fall back to git log
+    # below for a deterministic full-history listing.
+    if [[ -z "$previous_tag" ]]; then
+        echo "_No previous release tag found; listing all commits up to the promoted revision:_"
         echo
-        git log "origin/$base..$head" --pretty=format:"- %s (%h) -- @%an" --no-merges 2>/dev/null \
-            || echo "_(no commits found)_"
+        render_release_notes_git_log ""
         return
     fi
 
-    local commit_count
-    commit_count=$(jq '.commits | length' <<< "$compare_json")
+    local notes_json notes_body
+    notes_json=$(gh api --method POST "repos/$CICD_RELEASE_REPOSITORY/releases/generate-notes" \
+        -f "tag_name=$CICD_RELEASE_NEW_TAG" \
+        -f "target_commitish=$CICD_RELEASE_SOURCE_COMMIT" \
+        -f "previous_tag_name=$previous_tag" 2>/dev/null)
 
-    if [[ "$commit_count" == "0" ]]; then
-        echo "_No new commits in this release._"
+    if [[ -z "$notes_json" ]]; then
+        echo "_GitHub release-notes API unavailable; falling back to git log:_"
+        echo
+        render_release_notes_git_log "$previous_tag"
         return
     fi
 
-    if [[ "$commit_count" -ge 250 ]]; then
-        echo "_Release exceeds GitHub compare API limit (250 commits); falling back to git log:_"
-        echo
-        git log "origin/$base..$head" --pretty=format:"- %s (%h) -- @%an" --no-merges
+    notes_body=$(jq -r '.body // empty' <<< "$notes_json")
+    if [[ -z "$notes_body" ]]; then
+        echo "_No changes since previous release ($previous_tag)._"
         return
     fi
 
-    local breaking="" features="" fixes="" other="" direct=""
-    local seen_prs=" "
-    local sha
-
-    while IFS= read -r sha; do
-        local pulls_json
-        pulls_json=$(gh api "repos/$CICD_RELEASE_REPOSITORY/commits/$sha/pulls" 2>/dev/null)
-
-        if [[ -z "$pulls_json" || "$(jq 'length' <<< "$pulls_json" 2>/dev/null)" == "0" ]]; then
-            local subj short_sha
-            subj=$(jq -r --arg s "$sha" '.commits[] | select(.sha == $s) | .commit.message' <<< "$compare_json" | head -n1)
-            short_sha=${sha:0:7}
-            direct+="- ${subj:-$sha} ($short_sha)"$'\n'
-            continue
-        fi
-
-        local pr_number pr_title pr_user pr_labels entry
-        pr_number=$(jq -r '.[0].number' <<< "$pulls_json")
-
-        if [[ "$seen_prs" == *" $pr_number "* ]]; then
-            continue
-        fi
-        seen_prs+="$pr_number "
-
-        pr_title=$(jq -r '.[0].title' <<< "$pulls_json")
-        pr_user=$(jq -r '.[0].user.login' <<< "$pulls_json")
-        pr_labels=$(jq -r '.[0].labels[]?.name // empty' <<< "$pulls_json" | tr '\n' ' ')
-
-        entry="- #$pr_number $pr_title (@$pr_user)"$'\n'
-
-        if echo "$pr_labels" | grep -qiE '(^| )(breaking|breaking-change)( |$)'; then
-            breaking+="$entry"
-        elif echo "$pr_labels" | grep -qiE '(^| )(feat|feature|enhancement)( |$)'; then
-            features+="$entry"
-        elif echo "$pr_labels" | grep -qiE '(^| )(fix|bug|bugfix)( |$)'; then
-            fixes+="$entry"
-        else
-            other+="$entry"
-        fi
-    done < <(jq -r '.commits[].sha' <<< "$compare_json")
-
-    if [[ -n "$breaking" ]]; then
-        echo "### Breaking Changes"
-        echo
-        printf '%s' "$breaking"
-        echo
-    fi
-    if [[ -n "$features" ]]; then
-        echo "### Features"
-        echo
-        printf '%s' "$features"
-        echo
-    fi
-    if [[ -n "$fixes" ]]; then
-        echo "### Fixes"
-        echo
-        printf '%s' "$fixes"
-        echo
-    fi
-    if [[ -n "$other" ]]; then
-        echo "### Other Changes"
-        echo
-        printf '%s' "$other"
-        echo
-    fi
-    if [[ -n "$direct" ]]; then
-        echo "### Direct Commits"
-        echo
-        printf '%s' "$direct"
-        echo
-    fi
+    echo "_Changes since $previous_tag._"
+    echo
+    echo "$notes_body"
 }
 
 render_llm_summary() {
@@ -222,7 +202,7 @@ render_llm_summary() {
     local notes_body="$1"
     [[ -n "$notes_body" ]] || return 0
 
-    local model_id="${CICD_RELEASE_LLM_MODEL_ID:-anthropic.claude-haiku-4-5}"
+    local model_id="${CICD_RELEASE_LLM_MODEL_ID}"
 
     local request_file response_file
     request_file=$(mktemp)
@@ -236,7 +216,6 @@ render_llm_summary() {
             content: ("Summarize this software release in 1-2 paragraphs for a deployment PR description. Focus on themes and user-facing impact. Do not restate the bullet list verbatim. Release contents:\n\n" + $notes)
         }]
     }' > "$request_file"
-
     if aws bedrock-runtime invoke-model \
         --model-id "$model_id" \
         --body "fileb://$request_file" \
@@ -312,13 +291,24 @@ EXISTING_PR_NUMBER=$(gh pr list -B $CICD_RELEASE_TARGET_BRANCH -L 1 | cut -f1)
 if [[ ! -z $EXISTING_PR_NUMBER ]]; then
     echo "==> Pull Request already exists ($EXISTING_PR_NUMBER). Updating..."
 
-    # Update the PR message
-    echo "" >> $CICD_RELEASE_PR_MESSAGE_FILE
-    echo "---" >> $CICD_RELEASE_PR_MESSAGE_FILE
-    echo "# Previous Revisions" >> $CICD_RELEASE_PR_MESSAGE_FILE
-    echo "---" >> $CICD_RELEASE_PR_MESSAGE_FILE
-    echo "" >> $CICD_RELEASE_PR_MESSAGE_FILE
-    gh pr view --json body | jq -r '.body' >> $CICD_RELEASE_PR_MESSAGE_FILE
+    # Append the previous PR body as "Previous Revision", capped at ONE level of
+    # history. Earlier this appended the entire prior body -- which itself
+    # already contained a Previous Revision section -- so every update re-nested
+    # all prior history and the body grew ~quadratically toward GitHub's 65,536
+    # char PR-body limit. The HTML-comment sentinel marks where this run's own
+    # content ends and inherited history begins; we keep only the previous
+    # revision's content up to ITS sentinel, dropping everything it inherited.
+    PREVIOUS_BODY=$(gh pr view "$EXISTING_PR_NUMBER" --json body | jq -r '.body')
+    PREVIOUS_BODY=$(awk '/<!-- cicd-release:history-below -->/{exit} {print}' <<< "$PREVIOUS_BODY")
+    {
+        echo ""
+        echo "<!-- cicd-release:history-below -->"
+        echo "---"
+        echo "# Previous Revision"
+        echo "---"
+        echo ""
+        printf '%s\n' "$PREVIOUS_BODY"
+    } >> "$CICD_RELEASE_PR_MESSAGE_FILE"
 
     gh pr edit $EXISTING_PR_NUMBER \
         --title "$CICD_RELEASE_PR_TITLE" \
@@ -328,9 +318,35 @@ else
 
     echo "==> Creating new Pull Request"
 
+    # Only pass --reviewer when reviewers are configured; gh errors on an empty value.
+    reviewer_args=()
+    if [[ -n "$CICD_RELEASE_REVIEWER" ]]; then
+        reviewer_args=(--reviewer "$CICD_RELEASE_REVIEWER")
+    fi
+
     gh pr create \
         --base $CICD_RELEASE_TARGET_BRANCH \
         --title "$CICD_RELEASE_PR_TITLE" \
         --body-file "$CICD_RELEASE_PR_MESSAGE_FILE" \
-        --reviewer "$CICD_RELEASE_REVIEWER"
+        "${reviewer_args[@]}"
+fi
+
+
+###################################
+# Tag the promoted revision
+###################################
+# This tag becomes the `previous_tag_name` for the NEXT promotion's generated
+# release notes, chaining each release to the last. It is created at the source
+# (promoted) commit, on the source line. resolve_previous_release_tag() selects
+# the next range start from this same source line (`git tag --merged
+# $SOURCE_COMMIT`), so the chain is independent of how the promotion PR merges
+# into the target -- merge commit, squash, and rebase all work, because the
+# source branch is never rewritten.
+echo
+echo "==> Tagging promoted revision: $CICD_RELEASE_NEW_TAG -> $CICD_RELEASE_GIT_SHORT_COMMIT"
+git tag -f "$CICD_RELEASE_NEW_TAG" "$CICD_RELEASE_SOURCE_COMMIT"
+if git push -f origin "refs/tags/$CICD_RELEASE_NEW_TAG"; then
+    echo "==> Pushed release tag $CICD_RELEASE_NEW_TAG"
+else
+    echo "==! Failed to push release tag $CICD_RELEASE_NEW_TAG; next release's notes range may be wider than intended." >&2
 fi


### PR DESCRIPTION
## What's in this Change?

Enhances the CI/CD release-PR creation flow (`cicd-release.sh` + `BasePipelineStack.add_promotion_stage`) with auto-generated release notes, an optional LLM summary, and per-service customization hooks.

### Auto-generated Release Notes

`render_release_notes_body` replaces the previous "(fill me please)" placeholder. It uses the GitHub compare API + per-commit `commits/{sha}/pulls` lookups to:

- Associate each commit with its originating PR (deduped by PR number)
- Bucket entries into **Breaking Changes / Features / Fixes / Other / Direct Commits** based on PR labels (`breaking`, `feat|feature|enhancement`, `fix|bug|bugfix`)
- Fall back to `git log --no-merges` if the compare API is unavailable, returns 0 commits, or hits the 250-commit cap

### Optional Bedrock LLM Summary

Opt-in narrative summary prepended to the release notes via `aws bedrock-runtime invoke-model`. Defaults to `anthropic.claude-haiku-4-5` (cheap and plenty capable for a 2-3 sentence summary). The CodeBuild role automatically gets a scoped `bedrock:InvokeModel` policy (covering both `inference-profile/*` and `foundation-model/*` to support cross-region inference profiles) only when the summary is enabled.

### Customization Hooks on `BasePipelineStack`

New override properties for service-specific behavior, all keyed by `EnvType` of the promotion target:

| Property | Type | Purpose |
| --- | --- | --- |
| `release_reviewers` | `Mapping[EnvType, Sequence[str]]` | Per-target reviewer override |
| `default_release_reviewers` | `Sequence[str]` | Team-wide fallback (defaults to `AllenInstitute/aibs-data-solution`) |
| `release_checklists` | `Mapping[EnvType, Sequence[str]]` | Per-target checklist items rendered as `- [ ]` boxes |
| `release_extra_sections` | `Mapping[EnvType, Mapping[str, str]]` | Per-target extra markdown sections (heading → body) |
| `release_notes_llm_summary` | `bool` | Toggle the Bedrock summary |
| `release_llm_model_id` | `str` | Override the Bedrock model id |

All sections are omitted from the rendered PR body when the corresponding property returns no entry for the active promotion target — no empty placeholders.

### New CodeBuild Environment Variables

Passed from Python → bash via `partial_build_spec.env.variables`:

- `CICD_RELEASE_REPOSITORY` — `owner/repo` for `gh api` calls
- `CICD_RELEASE_CHECKLIST` — newline-separated checklist items
- `CICD_RELEASE_EXTRA_SECTIONS_JSON` — JSON object of `{heading: body}`
- `CICD_RELEASE_LLM_SUMMARY` — `"true"`/`"false"`
- `CICD_RELEASE_LLM_MODEL_ID` — Bedrock model id (only set when LLM summary is enabled)

## Testing

- [ ] Local dry-run of `cicd-release.sh` against a real repo with a stubbed `gh pr create/edit` to verify rendered markdown across each section combination (with/without checklist, with/without extra sections, with/without LLM summary)
- [ ] Local dry-run targeting a commit range with mixed PR labels to verify bucketing (Breaking / Features / Fixes / Other / Direct Commits)
- [ ] Verify fallback paths: missing `CICD_RELEASE_REPOSITORY`, compare API failure, 0 commits, and ≥250 commits
- [ ] Verify Bedrock LLM summary path with real AWS credentials (Haiku 4.5)
- [ ] `cdk synth` on a consuming pipeline stack — confirm the `CreateReleasePullRequest` step has the expected env vars and that `bedrock:InvokeModel` IAM is present iff `release_notes_llm_summary` is True
- [ ] Deploy to a sandbox stage and trigger a real release end-to-end