### PR TITLE
ExternalSnsTrigger: add enable_sns_subscription flag.

### DIFF
--- a/src/aibs_informatics_cdk_lib/constructs_/external_sns_trigger.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/external_sns_trigger.py
@@ -47,6 +47,7 @@ class ExternalSnsTrigger(constructs.Construct):
         triggered_lambda_fn=self.pts_listener_fn,
         external_sns_event_name="merscope-imaging-process",
         external_sns_topic_arn=f"arn:aws:sns:us-west-2:{account_id}:{sns_topic_name}",
+        sns_subscription_enabled=True,
     )
 
     NOTE: The `triggered_lambda_fn` is optional and if you have an alternative arrangement
@@ -79,7 +80,7 @@ class ExternalSnsTrigger(constructs.Construct):
         external_sns_event_dlq_name: str | None = None,
         external_sns_event_queue_retention_period: cdk.Duration | None = cdk.Duration.days(7),
         sqs_event_source_enabled: bool | None = None,
-        enable_sns_subscription: bool = True,
+        sns_subscription_enabled: bool | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope=scope, id=id)
@@ -91,6 +92,9 @@ class ExternalSnsTrigger(constructs.Construct):
 
         if sqs_event_source_enabled is None:
             sqs_event_source_enabled = env_base.env_type is EnvType.PROD
+
+        if sns_subscription_enabled is None:
+            sns_subscription_enabled = env_base.env_type is EnvType.PROD
 
         self.external_sns_event_dlq = sqs.Queue(
             scope=self,
@@ -124,7 +128,7 @@ class ExternalSnsTrigger(constructs.Construct):
 
         # Useful reference:
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sns/Subscription.html#aws_cdk.aws_sns.Subscription
-        if enable_sns_subscription:
+        if sns_subscription_enabled:
             self.external_sns_topic.add_subscription(
                 SqsSubscription(
                     queue=self.external_sns_event_queue,

--- a/src/aibs_informatics_cdk_lib/constructs_/external_sns_trigger.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/external_sns_trigger.py
@@ -79,6 +79,7 @@ class ExternalSnsTrigger(constructs.Construct):
         external_sns_event_dlq_name: str | None = None,
         external_sns_event_queue_retention_period: cdk.Duration | None = cdk.Duration.days(7),
         sqs_event_source_enabled: bool | None = None,
+        enable_sns_subscription: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(scope=scope, id=id)
@@ -123,12 +124,13 @@ class ExternalSnsTrigger(constructs.Construct):
 
         # Useful reference:
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_sns/Subscription.html#aws_cdk.aws_sns.Subscription
-        self.external_sns_topic.add_subscription(
-            SqsSubscription(
-                queue=self.external_sns_event_queue,
-                raw_message_delivery=True,
+        if enable_sns_subscription:
+            self.external_sns_topic.add_subscription(
+                SqsSubscription(
+                    queue=self.external_sns_event_queue,
+                    raw_message_delivery=True,
+                )
             )
-        )
 
         if triggered_lambda_fn is not None:
             triggered_lambda_fn.add_event_source(

--- a/test/aibs_informatics_cdk_lib/constructs_/test_external_sns_trigger.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/test_external_sns_trigger.py
@@ -1,3 +1,4 @@
+from aibs_informatics_core.env import EnvBase, EnvType
 from aws_cdk import aws_lambda as lambda_
 
 from aibs_informatics_cdk_lib.constructs_.external_sns_trigger import ExternalSnsTrigger
@@ -15,6 +16,7 @@ class TestExternaSnsTriggerStack(CdkBaseTest):
             triggered_lambda_fn=None,
             external_sns_event_name="test-event",
             external_sns_topic_arn="arn:aws:sns:us-west-2:123456789012:TestTopic",
+            sns_subscription_enabled=True,
         )
 
         template = self.get_template(stack)
@@ -42,6 +44,7 @@ class TestExternaSnsTriggerStack(CdkBaseTest):
             triggered_lambda_fn=triggered_lambda_fn,
             external_sns_event_name="test-event",
             external_sns_topic_arn="arn:aws:sns:us-west-2:123456789012:TestTopic",
+            sns_subscription_enabled=True,
         )
 
         assert trigger_construct.queue_name == self.env_base.prefixed(
@@ -56,7 +59,6 @@ class TestExternaSnsTriggerStack(CdkBaseTest):
         template.resource_count_is("AWS::SQS::QueuePolicy", 1)
         template.resource_count_is("AWS::CloudWatch::Alarm", 1)
 
-
     def test__init__with_sns_subscription_disabled(self):
         stack = self.get_dummy_stack("dummy-test-stack")
 
@@ -67,7 +69,6 @@ class TestExternaSnsTriggerStack(CdkBaseTest):
             triggered_lambda_fn=None,
             external_sns_event_name="test-event",
             external_sns_topic_arn="arn:aws:sns:us-west-2:123456789012:TestTopic",
-            enable_sns_subscription=False,
         )
 
         # The topic reference should still be set even when subscription is disabled
@@ -80,6 +81,44 @@ class TestExternaSnsTriggerStack(CdkBaseTest):
         # The rest of the resources should still be created
         template.resource_count_is("AWS::SQS::Queue", 2)
         template.resource_count_is("AWS::CloudWatch::Alarm", 1)
+
+    def test__init__sns_subscription_defaults_disabled_in_non_prod(self):
+        # In non-PROD envs, the subscription defaults to disabled
+        stack = self.get_dummy_stack("dummy-test-stack")
+
+        trigger_construct = ExternalSnsTrigger(
+            scope=stack,
+            id="test-external-sns-trigger",
+            env_base=self.env_base,
+            triggered_lambda_fn=None,
+            external_sns_event_name="test-event",
+            external_sns_topic_arn="arn:aws:sns:us-west-2:123456789012:TestTopic",
+        )
+
+        # The topic reference should still be set even when subscription is disabled
+        assert trigger_construct.external_sns_topic is not None
+
+        template = self.get_template(stack)
+        template.resource_count_is("AWS::SNS::Subscription", 0)
+        template.resource_count_is("AWS::SQS::QueuePolicy", 0)
+
+    def test__init__sns_subscription_defaults_enabled_in_prod(self):
+        # In PROD, the subscription defaults to enabled
+        self.env_base = EnvBase.from_type_and_label(EnvType.PROD, "marmotprod")
+        stack = self.get_dummy_stack("dummy-test-stack")
+
+        ExternalSnsTrigger(
+            scope=stack,
+            id="test-external-sns-trigger",
+            env_base=self.env_base,
+            triggered_lambda_fn=None,
+            external_sns_event_name="test-event",
+            external_sns_topic_arn="arn:aws:sns:us-west-2:123456789012:TestTopic",
+        )
+
+        template = self.get_template(stack)
+        template.resource_count_is("AWS::SNS::Subscription", 1)
+        template.resource_count_is("AWS::SQS::QueuePolicy", 1)
 
     def test__init__with_queue_and_dlq_name_properties(self):
         stack = self.get_dummy_stack("dummy-test-stack")

--- a/test/aibs_informatics_cdk_lib/constructs_/test_external_sns_trigger.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/test_external_sns_trigger.py
@@ -56,6 +56,31 @@ class TestExternaSnsTriggerStack(CdkBaseTest):
         template.resource_count_is("AWS::SQS::QueuePolicy", 1)
         template.resource_count_is("AWS::CloudWatch::Alarm", 1)
 
+
+    def test__init__with_sns_subscription_disabled(self):
+        stack = self.get_dummy_stack("dummy-test-stack")
+
+        trigger_construct = ExternalSnsTrigger(
+            scope=stack,
+            id="test-external-sns-trigger",
+            env_base=self.env_base,
+            triggered_lambda_fn=None,
+            external_sns_event_name="test-event",
+            external_sns_topic_arn="arn:aws:sns:us-west-2:123456789012:TestTopic",
+            enable_sns_subscription=False,
+        )
+
+        # The topic reference should still be set even when subscription is disabled
+        assert trigger_construct.external_sns_topic is not None
+
+        template = self.get_template(stack)
+        # No subscription (or its associated queue policy) should be created
+        template.resource_count_is("AWS::SNS::Subscription", 0)
+        template.resource_count_is("AWS::SQS::QueuePolicy", 0)
+        # The rest of the resources should still be created
+        template.resource_count_is("AWS::SQS::Queue", 2)
+        template.resource_count_is("AWS::CloudWatch::Alarm", 1)
+
     def test__init__with_queue_and_dlq_name_properties(self):
         stack = self.get_dummy_stack("dummy-test-stack")
 


### PR DESCRIPTION
## Background

We realized that we have a need to be able to configure `ExternalSnsTrigger` to enable the SQS Queue → Lambda trigger but _disable_ the SNS Topic → SQS Queue. This is useful in dev environments where we don't want to have the queue receive messages from a topic that can be noisy or unpredictable, but still be able to test the Lambda and downstream workflows by sending a message to the queue.

# Changes in PR

This PR adds a flag `enable_sns_subscription` defaulting to True that when set to False will avoid subscribing to the SNS topic arn.