### PR TITLE
DT-9926 (2/3): DockerAsset construct and image URI resolution

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,65 @@
+# AIBS Informatics CDK Library
+
+A CDK construct library for AIBS Informatics services. Its distinctive concern is
+**asset provisioning**: turning a versioned reference to one of our Python packages into
+something AWS can run — a Lambda zip, a container image for Batch, ECS, or Lambda.
+
+## Language
+
+### Sources
+
+**Source**:
+A reference to a specific version of one of our packages, before anything has been built
+or resolved. Every Asset is produced from exactly one Source.
+_Avoid_: repo, repo URL (a Source is not always a repository)
+
+**Git Source**:
+A Source naming a git repository and, optionally, a Ref within it.
+
+**Container Image Source**:
+A Source naming a pre-built image already published to a registry.
+_Avoid_: GHCR source, image URL, registry URL
+
+**Ref**:
+The point in a Git Source's history to use — a branch, a tag, or a commit. Branch and
+tag are interchangeable everywhere we resolve them; commit is not, and is the only
+distinction that changes behaviour.
+
+**Version ID**:
+The deterministic identifier for the exact version a Source names. Used to tag a Mirror
+so the same upstream version always lands under the same name.
+
+### Assets
+
+**Asset**:
+The deployable artifact produced or resolved from a Source. An Asset knows how to present
+itself to each AWS service that can consume it.
+_Avoid_: artifact, bundle, package (when the Asset is meant)
+
+**Code Asset**:
+An Asset that is a Lambda deployment package (a zip). Only ever produced from a Git
+Source, because it requires a checkout to build.
+
+**Docker Asset**:
+An Asset that is a container image, whether built locally from a Git Source or resolved
+from a Container Image Source. The unit that carries per-service representations.
+_Avoid_: docker image asset (that is the CDK type it may wrap, not our concept)
+
+**Assets Construct**:
+A named collection of Assets belonging to one project. Downstream repos subclass ours and
+add their own Assets to it. It is a namespace, never a single Asset.
+
+### Registries
+
+**Direct Pull**:
+Consuming a Container Image Source at its original registry — the workload pulls straight
+from where it was published.
+
+**Mirror**:
+A copy of a Container Image Source replicated into an ECR repository at deploy time, so
+workloads pull in-region. Opt-in.
+_Avoid_: sync, replication, cache
+
+**Digest Pinning**:
+Resolving a mutable tag to its immutable content digest, so that a reference names one
+exact image forever.

--- a/docs/adr/0001-docker-asset-is-its-own-construct.md
+++ b/docs/adr/0001-docker-asset-is-its-own-construct.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+---
+
+# A Docker Asset is its own construct, not a property of the assets construct
+
+Each AWS service consumes a container image differently — Batch wants a URI string, ECS
+wants an `ecs.ContainerImage`, Lambda wants a `lambda_.DockerImageCode`. The obvious place
+to expose those is as properties on `AIBSInformaticsDockerAssets` (`lambda_code`,
+`ecs_image`, …), but that construct is a *namespace*: five downstream repos subclass it and
+add their own `cached_property` members for their own images. A per-representation property
+on the namespace can only ever describe one of the assets in it. So we introduce a
+`DockerAsset` construct representing a single image — built locally from a Git Source or
+resolved from a Container Image Source — and hang the per-service representations off that.
+
+## Consequences
+
+`AIBSInformaticsDockerAssets.AIBS_INFORMATICS_AWS_LAMBDA` now returns a `DockerAsset`
+rather than a raw `aws_ecr_assets.DockerImageAsset`. This is source-compatible in practice:
+all eight downstream call sites pass it into a parameter that does
+`isinstance(x, str) → x, else x.image_uri`, and `DockerAsset` exposes `.image_uri`. The
+Step Functions fragment signatures are widened via a `DockerAssetLike` alias and a shared
+`resolve_image_uri()` helper, which also removes eight copies of that same ternary.
+
+`DockerAsset` is a `constructs.Construct` rather than a plain value object specifically so
+it can own child constructs — the ECR repository and `ECRDeployment` used by
+[ADR-0002](./0002-direct-ghcr-pull-with-opt-in-ecr-mirroring.md).
+
+`as_lambda_code()` raises on an unmirrored Container Image Source. This is an AWS
+constraint, not a gap in our implementation: Lambda container images must live in ECR, and
+`DockerImageCode` offers only `from_ecr()` and `from_image_asset()`. Mirroring is the fix,
+and we require it to be requested explicitly rather than provisioning an ECR repository as
+a side effect of a property access.

--- a/docs/adr/0002-direct-ghcr-pull-with-opt-in-ecr-mirroring.md
+++ b/docs/adr/0002-direct-ghcr-pull-with-opt-in-ecr-mirroring.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+---
+
+# Pull published images directly from GHCR, with ECR mirroring opt-in
+
+`aibs-informatics-aws-lambda` now publishes to `ghcr.io/alleninstitute/aibs-informatics-aws-lambda`,
+so CDK no longer has to clone and build that repo. We consume those images **directly by
+URI** by default, and offer ECR mirroring as an opt-in per `DockerAsset`. Direct pull needs
+no new dependency and no ECR lifecycle; mirroring exists for the cases that genuinely need
+it — in-region pull cost, independence from GitHub availability, and Lambda container
+images, which AWS requires to be in ECR.
+
+## Considered options
+
+Mirroring-always was rejected on dependency grounds rather than architectural ones.
+`cdk-ecr-deployment` is proven in-house (`gcs-infra` runs three `ECRDeployment`s today) but
+`gcs`, `ocs`, and `ocs-deploy` all pin `~=3.1.13` while upstream supports only v4. A hard
+dependency on either major forces a coordinated multi-repo change; declaring it as an
+optional `ecr-mirror` extra with a lazy import and a `>=3.1,<5` range avoids the resolver
+conflict entirely and matches the fact that mirroring is already opt-in.
+
+Registry throttling was raised as an argument for mirroring and does not hold up: GHCR
+publishes no pull rate limit for public packages and public package usage is free, unlike
+Docker Hub's 100-pulls-per-6h anonymous cap. The real cost of direct pull is NAT gateway
+data processing — roughly $0.045/GB, paid on each fresh Batch instance, since
+`ECS_IMAGE_PULL_BEHAVIOR=default` caches per instance rather than per job. That is the
+number to weigh when deciding whether to mirror.
+
+## Consequences
+
+**Mirror sources must be digest-pinned.** CloudFormation invokes a custom resource only
+when its properties change, so mirroring `:latest` → `:latest` would run once and then
+freeze the ECR copy forever while `latest` moved on. Enabling a mirror therefore resolves
+the source tag to its immutable digest at synth time, via an anonymous OCI token plus a
+manifest `HEAD` using stdlib `urllib` — no new dependency. Synth then requires network
+access to the registry when mirroring is enabled; supplying a digest explicitly skips the
+lookup and keeps synth offline-capable. Resolution failure is a hard error naming that fix,
+never a silent fallback to the mutable tag.
+
+**Mirrored images carry two tags.** A sanitized digest tag (`sha256-<hex>`, since `:` is
+illegal in an ECR tag) for immutable reference, plus the original source tag as a moving
+alias. `ECRDeployment` takes one source/destination pair, so this is two constructs — but
+the second is nearly free, as the layers already exist in the destination and the copy
+skips blobs already present. `mirror_tags` overrides the default when that cost matters.
+
+**Private packages are documented, not solved.** The package is public today. If it goes
+private, both synth-time digest resolution and the Batch pull need credentials — and
+`RegisterJobDefinition` has no `repositoryCredentials` parameter, so the only lever for the
+pull is ECS agent auth on the Batch launch template. The digest resolver keeps its auth
+header pluggable so a token can be added cheaply, but no credential plumbing is built.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,9 @@ nav:
           - Overview: api/project/index.md
           - Config: api/project/config.md
           - Utils: api/project/utils.md
+  - Decisions:
+      - Docker Asset construct: adr/0001-docker-asset-is-its-own-construct.md
+      - GHCR pull and ECR mirroring: adr/0002-direct-ghcr-pull-with-opt-in-ecr-mirroring.md
 
 extra:
   social:

--- a/src/aibs_informatics_cdk_lib/common/git.py
+++ b/src/aibs_informatics_cdk_lib/common/git.py
@@ -145,7 +145,13 @@ def is_local_repo(repo_path: str | Path) -> bool:
     """
     repo_path = Path(repo_path)
     try:
-        subprocess.check_output(["git", "-C", repo_path, "rev-parse", "--is-inside-work-tree"])
+        # This is a predicate, and it is routinely asked about values that are not paths
+        # at all (e.g. a container image reference). git's complaint about those is noise,
+        # so it is discarded rather than printed on every synth.
+        subprocess.check_output(
+            ["git", "-C", repo_path, "rev-parse", "--is-inside-work-tree"],
+            stderr=subprocess.DEVNULL,
+        )
         return True
     except subprocess.CalledProcessError:
         return False

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/code_asset_definitions.py
@@ -18,6 +18,7 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset import (
     PYTHON_REGEX_EXCLUDES,
     CodeAsset,
 )
+from aibs_informatics_cdk_lib.constructs_.assets.docker_asset import DockerAsset
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
     GitSource,
@@ -301,20 +302,20 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
         )
 
     @cached_property
-    def AIBS_INFORMATICS_AWS_LAMBDA(self) -> aws_ecr_assets.DockerImageAsset | str:
+    def AIBS_INFORMATICS_AWS_LAMBDA(self) -> DockerAsset:
         """Returns a docker asset for aibs-informatics-aws-lambda.
 
-        When the source is a GitSource, returns a DockerImageAsset built from the repo.
-        When the source is a ContainerImageSource, returns the image URI string.
+        When the source is a GitSource, the image is built locally from the repo. When
+        the source is a ContainerImageSource, the published image is used as-is.
 
         Returns:
-            The docker image asset or image URI string.
+            The docker asset, which knows how to present itself to each AWS service.
 
         Raises:
             TypeError: If the source is neither a ContainerImageSource nor a GitSource.
         """
         if isinstance(self._source, ContainerImageSource):
-            return self._source.image_uri
+            return DockerAsset.from_registry(self, "aibs-informatics-aws-lambda", self._source)
         if not isinstance(self._source, GitSource):
             raise TypeError(
                 f"AIBSInformaticsDockerAssets requires a GitSource or ContainerImageSource, "
@@ -325,10 +326,11 @@ class AIBSInformaticsDockerAssets(constructs.Construct, AssetsMixin):
             self._source.repo_url_with_ref, AIBS_INFORMATICS_AWS_LAMBDA_REPO_ENV_VAR
         )
 
-        return aws_ecr_assets.DockerImageAsset(
+        return DockerAsset.from_local_build(
             self,
             "aibs-informatics-aws-lambda",
             directory=repo_path.as_posix(),
+            source=self._source,
             build_ssh="default",
             platform=aws_ecr_assets.Platform.LINUX_AMD64,
             asset_name="aibs-informatics-aws-lambda",

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/docker_asset.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/docker_asset.py
@@ -1,0 +1,301 @@
+"""A Docker Asset -- one container image and its per-service representations.
+
+Each AWS service consumes a container image differently: Batch wants a URI string, ECS
+wants an ``ecs.ContainerImage``, Lambda wants a ``lambda_.DockerImageCode``. Those
+representations belong to a single image, not to the Assets Construct that collects
+several of them, so they hang off ``DockerAsset``.
+
+``DockerAsset`` is a ``constructs.Construct`` rather than a plain value object so that it
+can own child constructs -- today the ``DockerImageAsset`` it builds, later the ECR
+repository and deployment used to mirror a Container Image Source in-region.
+"""
+
+import logging
+from typing import Any
+
+import constructs
+from aws_cdk import aws_ecr_assets as ecr_assets
+from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_lambda as lambda_
+
+from aibs_informatics_cdk_lib.constructs_.assets.source import (
+    ContainerImageSource,
+    PackageSource,
+)
+
+logger = logging.getLogger(__name__)
+
+IMAGE_CONSTRUCT_ID = "Image"
+"""Construct id of the ``DockerImageAsset`` a locally built ``DockerAsset`` owns."""
+
+
+class DockerAsset(constructs.Construct):
+    """A single container image, built locally or resolved from a registry.
+
+    Use the factories rather than the constructor: ``from_source`` when you have a
+    Source, ``from_local_build`` when you have a docker build context, and
+    ``from_registry`` when you have a pre-built image reference.
+    """
+
+    def __init__(
+        self,
+        scope: constructs.Construct,
+        id: str,
+        *,
+        directory: str | None = None,
+        registry_image_uri: str | None = None,
+        source: PackageSource | None = None,
+        **image_asset_props: Any,
+    ) -> None:
+        """Create a Docker Asset from exactly one of a build context or a registry URI.
+
+        Args:
+            scope: The parent construct.
+            id: The construct id.
+            directory: The docker build context to build the image from. Mutually
+                exclusive with ``registry_image_uri``.
+            registry_image_uri: The URI of a pre-built image in a registry. Mutually
+                exclusive with ``directory``.
+            source: The Source this image was produced from, recorded for provenance.
+            **image_asset_props: Additional props forwarded to
+                ``aws_ecr_assets.DockerImageAsset`` (e.g. ``file``, ``platform``,
+                ``build_ssh``, ``asset_name``, ``extra_hash``, ``exclude``). Only valid
+                alongside ``directory``.
+
+        Raises:
+            ValueError: If neither or both of ``directory`` and ``registry_image_uri``
+                are given, or if image asset props are given without a ``directory``.
+        """
+        super().__init__(scope, id)
+
+        if (directory is None) == (registry_image_uri is None):
+            raise ValueError(
+                "DockerAsset requires exactly one of `directory` (build the image) or "
+                "`registry_image_uri` (use a pre-built image)."
+            )
+        if directory is None and image_asset_props:
+            raise ValueError(
+                f"Docker image asset props {sorted(image_asset_props)} are only valid when "
+                "building from a `directory`."
+            )
+
+        self._source = source
+        self._registry_image_uri = registry_image_uri
+        self._image_asset = (
+            ecr_assets.DockerImageAsset(
+                self, IMAGE_CONSTRUCT_ID, directory=directory, **image_asset_props
+            )
+            if directory is not None
+            else None
+        )
+
+    # -----------------------------------------------------------------------------
+    # Factories
+    # -----------------------------------------------------------------------------
+
+    @classmethod
+    def from_source(
+        cls,
+        scope: constructs.Construct,
+        id: str,
+        source: PackageSource,
+        *,
+        directory: str | None = None,
+        **image_asset_props: Any,
+    ) -> "DockerAsset":
+        """Create a Docker Asset from a Source, building or resolving as the Source requires.
+
+        A Container Image Source names an image that already exists, so it is used
+        directly. A Git Source has to be built, which needs a checkout -- pass the
+        directory it was checked out into.
+
+        Args:
+            scope: The parent construct.
+            id: The construct id.
+            source: The Source to produce the image from.
+            directory: The docker build context. Required for a Git Source, ignored for
+                a Container Image Source.
+            **image_asset_props: Additional props forwarded to
+                ``aws_ecr_assets.DockerImageAsset``.
+
+        Returns:
+            A Docker Asset for the given Source.
+
+        Raises:
+            ValueError: If the Source must be built but no ``directory`` was given.
+        """
+        if isinstance(source, ContainerImageSource):
+            return cls.from_registry(scope, id, source)
+        if directory is None:
+            raise ValueError(
+                f"Cannot build a Docker Asset from {type(source).__name__} without a "
+                "`directory` to build from. Resolve the Source to a checkout first."
+            )
+        return cls.from_local_build(
+            scope, id, directory=directory, source=source, **image_asset_props
+        )
+
+    @classmethod
+    def from_local_build(
+        cls,
+        scope: constructs.Construct,
+        id: str,
+        *,
+        directory: str,
+        source: PackageSource | None = None,
+        **image_asset_props: Any,
+    ) -> "DockerAsset":
+        """Create a Docker Asset by building an image from a local docker build context.
+
+        Args:
+            scope: The parent construct.
+            id: The construct id.
+            directory: The docker build context.
+            source: The Source the build context came from, recorded for provenance.
+            **image_asset_props: Additional props forwarded to
+                ``aws_ecr_assets.DockerImageAsset`` (e.g. ``file``, ``platform``,
+                ``build_ssh``, ``asset_name``, ``extra_hash``, ``exclude``).
+
+        Returns:
+            A Docker Asset wrapping the built image.
+        """
+        return cls(scope, id, directory=directory, source=source, **image_asset_props)
+
+    @classmethod
+    def from_registry(
+        cls,
+        scope: constructs.Construct,
+        id: str,
+        image: ContainerImageSource | str,
+    ) -> "DockerAsset":
+        """Create a Docker Asset from an image that is already published to a registry.
+
+        Args:
+            scope: The parent construct.
+            id: The construct id.
+            image: A Container Image Source, or an image URI string.
+
+        Returns:
+            A Docker Asset referencing the published image.
+        """
+        if isinstance(image, ContainerImageSource):
+            return cls(scope, id, registry_image_uri=image.image_uri, source=image)
+        return cls(scope, id, registry_image_uri=image)
+
+    # -----------------------------------------------------------------------------
+    # Accessors
+    # -----------------------------------------------------------------------------
+
+    @property
+    def source(self) -> PackageSource | None:
+        """The Source this image was produced from, if one was recorded."""
+        return self._source
+
+    @property
+    def docker_image_asset(self) -> ecr_assets.DockerImageAsset | None:
+        """The underlying CDK asset for a locally built image, or None for a registry image."""
+        return self._image_asset
+
+    @property
+    def image_uri(self) -> str:
+        """The most-local URI available for this image.
+
+        Prefers a URI in an ECR repository we control over the image's origin registry,
+        so that workloads pull in-region wherever that is possible.
+
+        Returns:
+            An image URI suitable for Batch, ECS, or anything else that takes a string.
+        """
+        return self.ecr_image_uri or self.source_image_uri
+
+    @property
+    def source_image_uri(self) -> str:
+        """The URI of this image where its Source puts it.
+
+        For a Container Image Source that is the origin registry. For a locally built
+        image there is no upstream registry, so it is the URI CDK publishes the built
+        asset to.
+
+        Returns:
+            The image URI at its origin.
+        """
+        if self._image_asset is not None:
+            return self._image_asset.image_uri
+        # The constructor guarantees one of the two is set.
+        return str(self._registry_image_uri)
+
+    @property
+    def ecr_image_uri(self) -> str | None:
+        """The URI of this image inside an ECR repository, or None if it is not in one.
+
+        A locally built image is published to the CDK asset repository, which is ECR. An
+        image resolved from a Container Image Source stays at its origin registry until
+        it is mirrored into ECR, which this construct does not yet do.
+
+        Returns:
+            The in-ECR image URI, or None when the image is only at its origin registry.
+        """
+        # NOTE: mirroring a Container Image Source into ECR resolves the None case.
+        if self._image_asset is not None:
+            return self._image_asset.image_uri
+        return None
+
+    def as_ecs_image(self) -> ecs.ContainerImage:
+        """Present this image to ECS.
+
+        ECS can pull directly from a public registry, so a Container Image Source needs
+        no mirroring to be usable here.
+
+        Returns:
+            The image as an ``ecs.ContainerImage``.
+        """
+        if self._image_asset is not None:
+            return ecs.ContainerImage.from_docker_image_asset(self._image_asset)
+        return ecs.ContainerImage.from_registry(self.image_uri)
+
+    def as_lambda_code(self) -> lambda_.DockerImageCode:
+        """Present this image to Lambda.
+
+        Returns:
+            The image as a ``lambda_.DockerImageCode``.
+
+        Raises:
+            ValueError: If the image is only available at its origin registry. Lambda
+                container images must live in ECR -- ``DockerImageCode`` offers only
+                ``from_ecr()`` and ``from_image_asset()`` -- so the image has to be
+                mirrored first. Provisioning that ECR repository here would create
+                infrastructure as a side effect of reading a property, so it has to be
+                asked for explicitly.
+        """
+        # NOTE: mirroring a Container Image Source into ECR gives this the repository and
+        # tag it needs, and the `from_ecr` call below serves that case unchanged.
+        if self._image_asset is None:
+            raise ValueError(
+                f"Cannot use '{self.source_image_uri}' as Lambda code: Lambda container "
+                "images must live in ECR, and this image is only available at its origin "
+                "registry. Pass `mirror_to_ecr=True` for this asset to copy it into ECR."
+            )
+        return lambda_.DockerImageCode.from_ecr(
+            self._image_asset.repository, tag_or_digest=self._image_asset.image_tag
+        )
+
+
+DockerAssetLike = ecr_assets.DockerImageAsset | DockerAsset | str
+"""Anything that can stand in for a container image reference.
+
+Downstream Assets Constructs expose raw ``DockerImageAsset`` members alongside our
+``DockerAsset`` ones, and callers sometimes have nothing but a URI string, so everything
+that consumes an image accepts all three.
+"""
+
+
+def resolve_image_uri(asset: DockerAssetLike) -> str:
+    """Resolve anything image-like to a container image URI.
+
+    Args:
+        asset: A ``DockerAsset``, a raw CDK ``DockerImageAsset``, or an image URI string.
+
+    Returns:
+        The container image URI.
+    """
+    return asset if isinstance(asset, str) else asset.image_uri

--- a/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/data_sync.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/data_sync.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable
 import constructs
 from aibs_informatics_core.env import EnvBase
 from aws_cdk import aws_batch as batch
-from aws_cdk import aws_ecr_assets as ecr_assets
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_stepfunctions as sfn
@@ -12,6 +11,10 @@ from aibs_informatics_cdk_lib.common.aws.iam_utils import (
     SFN_STATES_EXECUTION_ACTIONS,
     SFN_STATES_READ_ACCESS_ACTIONS,
     sfn_policy_statement,
+)
+from aibs_informatics_cdk_lib.constructs_.assets.docker_asset import (
+    DockerAssetLike,
+    resolve_image_uri,
 )
 from aibs_informatics_cdk_lib.constructs_.base import EnvBaseConstructMixins
 from aibs_informatics_cdk_lib.constructs_.efs.file_system import MountPointConfiguration
@@ -27,7 +30,7 @@ class DataSyncFragment(BatchInvokedBaseFragment, EnvBaseConstructMixins):
         scope: constructs.Construct,
         id: str,
         env_base: EnvBase,
-        aibs_informatics_docker_asset: ecr_assets.DockerImageAsset | str,
+        aibs_informatics_docker_asset: DockerAssetLike,
         batch_job_queue: batch.JobQueue | str,
         scaffolding_bucket: s3.Bucket,
         batch_job_role: iam.Role | str | None = None,
@@ -40,8 +43,8 @@ class DataSyncFragment(BatchInvokedBaseFragment, EnvBaseConstructMixins):
             scope (Construct): construct scope
             id (str): id
             env_base (EnvBase): env base
-            aibs_informatics_docker_asset (DockerImageAsset|str): Docker image asset or image uri
-                str for the aibs informatics aws lambda
+            aibs_informatics_docker_asset (DockerAssetLike): Docker asset, docker image asset,
+                or image uri str for the aibs informatics aws lambda
             batch_job_queue (JobQueue|str): Default batch job queue or job queue name str that
                 the batch job will be submitted to. This can be override by the payload.
             scaffolding_bucket (Bucket): Primary bucket used for request/response json blobs used
@@ -55,11 +58,7 @@ class DataSyncFragment(BatchInvokedBaseFragment, EnvBaseConstructMixins):
         """
         super().__init__(scope, id, env_base)
 
-        aibs_informatics_image_uri = (
-            aibs_informatics_docker_asset
-            if isinstance(aibs_informatics_docker_asset, str)
-            else aibs_informatics_docker_asset.image_uri
-        )
+        aibs_informatics_image_uri = resolve_image_uri(aibs_informatics_docker_asset)
 
         self.batch_job_queue_name = (
             batch_job_queue if isinstance(batch_job_queue, str) else batch_job_queue.job_queue_name
@@ -127,7 +126,7 @@ class DistributedDataSyncFragment(BatchInvokedBaseFragment):
         scope: constructs.Construct,
         id: str,
         env_base: EnvBase,
-        aibs_informatics_docker_asset: ecr_assets.DockerImageAsset | str,
+        aibs_informatics_docker_asset: DockerAssetLike,
         batch_job_queue: batch.JobQueue | str,
         scaffolding_bucket: s3.Bucket,
         batch_job_role: str | iam.Role | None = None,
@@ -139,8 +138,8 @@ class DistributedDataSyncFragment(BatchInvokedBaseFragment):
             scope (constructs.Construct): construct scope
             id (str): id
             env_base (EnvBase): env base
-            aibs_informatics_docker_asset (DockerImageAsset|str): Docker image asset or image uri
-                str for the aibs informatics aws lambda
+            aibs_informatics_docker_asset (DockerAssetLike): Docker asset, docker image asset,
+                or image uri str for the aibs informatics aws lambda
             batch_job_queue (JobQueue|str): Default batch job queue or job queue name str that
                 the batch job will be submitted to. This can be override by the payload.
             scaffolding_bucket (Bucket): Primary bucket used for request/response json blobs used
@@ -152,6 +151,7 @@ class DistributedDataSyncFragment(BatchInvokedBaseFragment):
                 List of mount point configurations to use. These can be overridden in the payload.
         """
         super().__init__(scope, id, env_base)
+        aibs_informatics_image_uri = resolve_image_uri(aibs_informatics_docker_asset)
         start_pass_state = sfn.Pass(
             self,
             f"{id}: Start",
@@ -167,11 +167,7 @@ class DistributedDataSyncFragment(BatchInvokedBaseFragment):
             env_base=env_base,
             name=prep_batch_sync_task_name,
             payload_path="$.request",
-            image=(
-                aibs_informatics_docker_asset
-                if isinstance(aibs_informatics_docker_asset, str)
-                else aibs_informatics_docker_asset.image_uri
-            ),
+            image=aibs_informatics_image_uri,
             handler="aibs_informatics_aws_lambda.handlers.data_sync.prepare_batch_data_sync_handler",
             job_queue=(
                 batch_job_queue
@@ -204,11 +200,7 @@ class DistributedDataSyncFragment(BatchInvokedBaseFragment):
                 env_base=env_base,
                 name="batch-data-sync",
                 payload_path="$",
-                image=(
-                    aibs_informatics_docker_asset
-                    if isinstance(aibs_informatics_docker_asset, str)
-                    else aibs_informatics_docker_asset.image_uri
-                ),
+                image=aibs_informatics_image_uri,
                 handler="aibs_informatics_aws_lambda.handlers.data_sync.batch_data_sync_handler",
                 job_queue=(
                     batch_job_queue

--- a/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/demand_execution.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/demand_execution.py
@@ -3,7 +3,6 @@ from typing import Any
 import constructs
 from aibs_informatics_core.env import EnvBase
 from aws_cdk import aws_batch as batch
-from aws_cdk import aws_ecr_assets as ecr_assets
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_stepfunctions as sfn
@@ -17,6 +16,10 @@ from aibs_informatics_cdk_lib.common.aws.iam_utils import (
     sfn_policy_statement,
 )
 from aibs_informatics_cdk_lib.common.aws.sfn_utils import JsonReferencePath
+from aibs_informatics_cdk_lib.constructs_.assets.docker_asset import (
+    DockerAssetLike,
+    resolve_image_uri,
+)
 from aibs_informatics_cdk_lib.constructs_.base import EnvBaseConstructMixins
 from aibs_informatics_cdk_lib.constructs_.efs.file_system import MountPointConfiguration
 from aibs_informatics_cdk_lib.constructs_.sfn.fragments.base import EnvBaseStateMachineFragment
@@ -29,7 +32,7 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
         scope: constructs.Construct,
         id: str,
         env_base: EnvBase,
-        aibs_informatics_docker_asset: ecr_assets.DockerImageAsset | str,
+        aibs_informatics_docker_asset: DockerAssetLike,
         scaffolding_bucket: s3.Bucket,
         scaffolding_job_queue: batch.JobQueue | str,
         batch_invoked_lambda_state_machine: sfn.StateMachine,
@@ -64,9 +67,7 @@ class DemandExecutionFragment(EnvBaseStateMachineFragment, EnvBaseConstructMixin
         # - specify the mount points and volumes if provided
         batch_invoked_lambda_kwargs: dict[str, Any] = {
             "bucket_name": scaffolding_bucket.bucket_name,
-            "image": aibs_informatics_docker_asset
-            if isinstance(aibs_informatics_docker_asset, str)
-            else aibs_informatics_docker_asset.image_uri,
+            "image": resolve_image_uri(aibs_informatics_docker_asset),
             "job_queue": scaffolding_job_queue
             if isinstance(scaffolding_job_queue, str)
             else scaffolding_job_queue.job_queue_name,

--- a/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/efs.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/sfn/fragments/informatics/efs.py
@@ -4,13 +4,16 @@ from dataclasses import dataclass
 import constructs
 from aibs_informatics_core.env import EnvBase
 from aws_cdk import aws_batch as batch
-from aws_cdk import aws_ecr_assets as ecr_assets
 from aws_cdk import aws_efs as efs
 from aws_cdk import aws_events as events
 from aws_cdk import aws_events_targets as events_targets
 from aws_cdk import aws_s3 as s3
 from aws_cdk import aws_stepfunctions as sfn
 
+from aibs_informatics_cdk_lib.constructs_.assets.docker_asset import (
+    DockerAssetLike,
+    resolve_image_uri,
+)
 from aibs_informatics_cdk_lib.constructs_.efs.file_system import MountPointConfiguration
 from aibs_informatics_cdk_lib.constructs_.sfn.fragments.informatics.batch import (
     BatchInvokedBaseFragment,
@@ -22,7 +25,7 @@ def get_data_path_stats_fragment(
     scope: constructs.Construct,
     id: str,
     env_base: EnvBase,
-    aibs_informatics_docker_asset: ecr_assets.DockerImageAsset | str,
+    aibs_informatics_docker_asset: DockerAssetLike,
     batch_job_queue: batch.JobQueue | str,
     scaffolding_bucket: s3.Bucket,
     mount_point_configs: Iterable[MountPointConfiguration] | None = None,
@@ -35,7 +38,7 @@ def get_data_path_stats_fragment(
         scope (constructs.Construct): scope
         id (str): id of the fragment
         env_base (EnvBase): env base
-        aibs_informatics_docker_asset (Union[ecr_assets.DockerImageAsset, str]): docker image asset or image uri
+        aibs_informatics_docker_asset (DockerAssetLike): docker asset, docker image asset, or image uri
             that has the get_data_path_stats_handler function
         batch_job_queue (Union[batch.JobQueue, str]): default batch job queue or job queue name str that
             the batch job will be submitted to. This can be override by the payload.
@@ -53,11 +56,7 @@ def get_data_path_stats_fragment(
         id=id,
         env_base=env_base,
         name="get-data-path-stats",
-        image=(
-            aibs_informatics_docker_asset
-            if isinstance(aibs_informatics_docker_asset, str)
-            else aibs_informatics_docker_asset.image_uri
-        ),
+        image=resolve_image_uri(aibs_informatics_docker_asset),
         handler="aibs_informatics_aws_lambda.handlers.data_sync.get_data_path_stats_handler",
         job_queue=(
             batch_job_queue if isinstance(batch_job_queue, str) else batch_job_queue.job_queue_name
@@ -74,7 +73,7 @@ def outdated_data_path_scanner_fragment(
     scope: constructs.Construct,
     id: str,
     env_base: EnvBase,
-    aibs_informatics_docker_asset: ecr_assets.DockerImageAsset | str,
+    aibs_informatics_docker_asset: DockerAssetLike,
     batch_job_queue: batch.JobQueue | str,
     scaffolding_bucket: s3.Bucket,
     mount_point_configs: Iterable[MountPointConfiguration] | None = None,
@@ -87,7 +86,7 @@ def outdated_data_path_scanner_fragment(
         scope (constructs.Construct): scope
         id (str): id of the fragment
         env_base (EnvBase): env base
-        aibs_informatics_docker_asset (Union[ecr_assets.DockerImageAsset, str]): docker image asset or image uri
+        aibs_informatics_docker_asset (DockerAssetLike): docker asset, docker image asset, or image uri
             that has the outdated_data_path_scanner_handler function
         batch_job_queue (Union[batch.JobQueue, str]): default batch job queue or job queue name str that
             the batch job will be submitted to. This can be override by the payload.
@@ -106,11 +105,7 @@ def outdated_data_path_scanner_fragment(
         id=id,
         env_base=env_base,
         name="outdated-data-path-scanner",
-        image=(
-            aibs_informatics_docker_asset
-            if isinstance(aibs_informatics_docker_asset, str)
-            else aibs_informatics_docker_asset.image_uri
-        ),
+        image=resolve_image_uri(aibs_informatics_docker_asset),
         handler="aibs_informatics_aws_lambda.handlers.data_sync.outdated_data_path_scanner_handler",
         job_queue=(
             batch_job_queue if isinstance(batch_job_queue, str) else batch_job_queue.job_queue_name
@@ -129,7 +124,7 @@ def remove_data_paths_fragment(
     scope: constructs.Construct,
     id: str,
     env_base: EnvBase,
-    aibs_informatics_docker_asset: ecr_assets.DockerImageAsset | str,
+    aibs_informatics_docker_asset: DockerAssetLike,
     batch_job_queue: batch.JobQueue | str,
     scaffolding_bucket: s3.Bucket,
     mount_point_configs: Iterable[MountPointConfiguration] | None = None,
@@ -142,7 +137,7 @@ def remove_data_paths_fragment(
         scope (constructs.Construct): scope
         id (str): id of the fragment
         env_base (EnvBase): env base
-        aibs_informatics_docker_asset (Union[ecr_assets.DockerImageAsset, str]): docker image asset or image uri
+        aibs_informatics_docker_asset (DockerAssetLike): docker asset, docker image asset, or image uri
             that has the remove_data_paths_handler function
         batch_job_queue (Union[batch.JobQueue, str]): default batch job queue or job queue name str that
             the batch job will be submitted to. This can be override by the payload.
@@ -160,11 +155,7 @@ def remove_data_paths_fragment(
         id=id,
         env_base=env_base,
         name="remove-data-paths",
-        image=(
-            aibs_informatics_docker_asset
-            if isinstance(aibs_informatics_docker_asset, str)
-            else aibs_informatics_docker_asset.image_uri
-        ),
+        image=resolve_image_uri(aibs_informatics_docker_asset),
         handler="aibs_informatics_aws_lambda.handlers.data_sync.remove_data_paths_handler",
         job_queue=(
             batch_job_queue if isinstance(batch_job_queue, str) else batch_job_queue.job_queue_name
@@ -246,7 +237,7 @@ class CleanFileSystemFragment(BatchInvokedBaseFragment):
         scope: constructs.Construct,
         id: str,
         env_base: EnvBase,
-        aibs_informatics_docker_asset: ecr_assets.DockerImageAsset | str,
+        aibs_informatics_docker_asset: DockerAssetLike,
         batch_job_queue: batch.JobQueue | str,
         scaffolding_bucket: s3.Bucket,
         mount_point_configs: Iterable[MountPointConfiguration] | None = None,
@@ -259,8 +250,8 @@ class CleanFileSystemFragment(BatchInvokedBaseFragment):
             scope (Construct): construct scope
             id (str): id
             env_base (EnvBase): env base
-            aibs_informatics_docker_asset (DockerImageAsset|str): Docker image asset or image uri
-                str for the aibs informatics aws lambda
+            aibs_informatics_docker_asset (DockerAssetLike): Docker asset, docker image asset,
+                or image uri str for the aibs informatics aws lambda
             batch_job_queue (JobQueue|str): Default batch job queue or job queue name str that
                 the batch job will be submitted to. This can be override by the payload.
             primary_bucket (Bucket): Primary bucket used for request/response json blobs used in
@@ -274,11 +265,7 @@ class CleanFileSystemFragment(BatchInvokedBaseFragment):
         """  # noqa: E501
         super().__init__(scope, id, env_base)
 
-        aibs_informatics_image_uri = (
-            aibs_informatics_docker_asset
-            if isinstance(aibs_informatics_docker_asset, str)
-            else aibs_informatics_docker_asset.image_uri
-        )
+        aibs_informatics_image_uri = resolve_image_uri(aibs_informatics_docker_asset)
 
         start_pass_state = sfn.Pass(
             self,

--- a/test/aibs_informatics_cdk_lib/common/test_git.py
+++ b/test/aibs_informatics_cdk_lib/common/test_git.py
@@ -1,3 +1,4 @@
+import subprocess
 from unittest.mock import call, patch
 
 import pytest
@@ -190,6 +191,20 @@ def test__git_url__ref_and_ref_kind(repo_url, expected_ref, expected_ref_kind):
     git_url = GitUrl(repo_url)
     assert git_url.ref == expected_ref
     assert git_url.ref_kind == expected_ref_kind
+
+
+@patch("aibs_informatics_cdk_lib.common.git.subprocess.check_output")
+def test__is_local_repo__discards_git_stderr(mock_check_output):
+    """The predicate is asked about non-paths routinely; git's complaint is noise."""
+    assert is_local_repo("ghcr.io/org/repo:latest")
+    _, kwargs = mock_check_output.call_args
+    assert kwargs["stderr"] == subprocess.DEVNULL
+
+
+def test__is_local_repo__container_image_ref_stays_quiet(capfd):
+    """`PackageSource.from_str` probes this for every image ref, on every synth."""
+    assert not is_local_repo("ghcr.io/org/repo:latest")
+    assert capfd.readouterr().err == ""
 
 
 @patch("aibs_informatics_cdk_lib.common.git.subprocess.check_output")

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_code_asset_definitions.py
@@ -3,6 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aibs_informatics_cdk_lib.constructs_.assets.code_asset import (
+    GLOBAL_GLOB_EXCLUDES,
+    PYTHON_GLOB_EXCLUDES,
+)
 from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
     AIBS_INFORMATICS_AWS_LAMBDA_REPO,
     AIBSInformaticsAssets,
@@ -10,6 +14,7 @@ from aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions import (
     AIBSInformaticsDockerAssets,
     AssetsMixin,
 )
+from aibs_informatics_cdk_lib.constructs_.assets.docker_asset import DockerAsset
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
     GitSource,
@@ -215,8 +220,9 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
             stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
         result = assets.AIBS_INFORMATICS_AWS_LAMBDA
-        assert isinstance(result, str)
-        assert result == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:v1.2.3"
+        assert isinstance(result, DockerAsset)
+        assert result.image_uri == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:v1.2.3"
+        assert result.source is source
 
     def test__AIBS_INFORMATICS_AWS_LAMBDA__container_image_with_digest(self):
         stack = self.get_dummy_stack("test")
@@ -228,9 +234,10 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
             stack, "DockerAssets", self.env_base, aibs_informatics_aws_lambda_source=source
         )
         result = assets.AIBS_INFORMATICS_AWS_LAMBDA
-        assert isinstance(result, str)
+        assert isinstance(result, DockerAsset)
         assert (
-            result == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890"
+            result.image_uri
+            == "ghcr.io/alleninstitute/aibs-informatics-aws-lambda@sha256:abcdef1234567890"
         )
 
     @patch.object(AssetsMixin, "resolve_repo_path")
@@ -251,7 +258,7 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
         # but the DockerImageAsset constructor will fail without a real directory,
         # so we patch that too
         with patch(
-            "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.aws_ecr_assets.DockerImageAsset"
+            "aibs_informatics_cdk_lib.constructs_.assets.docker_asset.ecr_assets.DockerImageAsset"
         ):
             with patch(
                 "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash",
@@ -263,6 +270,36 @@ class TestAIBSInformaticsDockerAssets(CdkBaseTest):
             "git@github.com:org/repo.git#v1.0.0",
             "AIBS_INFORMATICS_AWS_LAMBDA_REPO",
         )
+
+    @patch.object(AssetsMixin, "resolve_repo_path")
+    def test__AIBS_INFORMATICS_AWS_LAMBDA__git_source_preserves_build_props(self, mock_resolve):
+        """The build props feed asset hashing and the ssh-backed build -- they must not drift."""
+        stack = self.get_dummy_stack("test")
+        assets = AIBSInformaticsDockerAssets(stack, "DockerAssets", self.env_base)
+
+        mock_path = MagicMock()
+        mock_path.as_posix.return_value = "/tmp/fake-repo"
+        mock_path.resolve.return_value = "/tmp/fake-repo"
+        mock_resolve.return_value = mock_path
+
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.docker_asset.ecr_assets.DockerImageAsset"
+        ) as mock_image_asset:
+            with patch(
+                "aibs_informatics_cdk_lib.constructs_.assets.code_asset_definitions.generate_path_hash",
+                return_value="fakehash",
+            ):
+                result = assets.AIBS_INFORMATICS_AWS_LAMBDA
+
+        assert isinstance(result, DockerAsset)
+        _, kwargs = mock_image_asset.call_args
+        assert kwargs["directory"] == "/tmp/fake-repo"
+        assert kwargs["file"] == "docker/Dockerfile"
+        assert kwargs["build_ssh"] == "default"
+        assert kwargs["asset_name"] == "aibs-informatics-aws-lambda"
+        assert kwargs["platform"].platform == "linux/amd64"
+        assert kwargs["extra_hash"] == "fakehash"
+        assert kwargs["exclude"] == [*PYTHON_GLOB_EXCLUDES, *GLOBAL_GLOB_EXCLUDES]
 
 
 # ---------------------------------------------------------------------------

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_docker_asset.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_docker_asset.py
@@ -1,0 +1,255 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from aws_cdk import aws_ecr_assets as ecr_assets
+from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_lambda as lambda_
+
+from aibs_informatics_cdk_lib.constructs_.assets.docker_asset import (
+    DockerAsset,
+    resolve_image_uri,
+)
+from aibs_informatics_cdk_lib.constructs_.assets.source import (
+    ContainerImageSource,
+    GitSource,
+)
+from test.aibs_informatics_cdk_lib.base import CdkBaseTest
+
+IMAGE_URI = "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:v1.2.3"
+
+
+class DockerAssetBaseTest(CdkBaseTest):
+    """Shared scaffolding for DockerAsset tests.
+
+    A local build needs a real build context on disk: ``DockerImageAsset`` stages and
+    fingerprints the directory at synth time. It does not invoke docker, so no image is
+    ever built and nothing leaves the machine.
+    """
+
+    def build_context(self) -> Path:
+        path = self.tmp_path()
+        (path / "docker").mkdir(parents=True, exist_ok=True)
+        (path / "docker" / "Dockerfile").write_text("FROM scratch\n")
+        return path
+
+    def local_build_asset(self, id: str = "LocalImage") -> DockerAsset:
+        stack = self.get_dummy_stack("test")
+        return DockerAsset.from_local_build(
+            stack,
+            id,
+            directory=self.build_context().as_posix(),
+            file="docker/Dockerfile",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestDockerAssetConstruction(DockerAssetBaseTest):
+    def test__init__requires_a_directory_or_a_registry_uri(self):
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="exactly one of"):
+            DockerAsset(stack, "Image")
+
+    def test__init__rejects_both_a_directory_and_a_registry_uri(self):
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="exactly one of"):
+            DockerAsset(
+                stack,
+                "Image",
+                directory=self.build_context().as_posix(),
+                registry_image_uri=IMAGE_URI,
+            )
+
+    def test__init__rejects_image_asset_props_without_a_directory(self):
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="only valid when building"):
+            DockerAsset(stack, "Image", registry_image_uri=IMAGE_URI, file="docker/Dockerfile")
+
+    def test__from_local_build__owns_the_image_asset_as_a_child(self):
+        """PR 3 hangs an ECR repository and mirror deployment off this construct."""
+        asset = self.local_build_asset()
+        assert isinstance(asset, DockerAsset)
+        assert asset.docker_image_asset is not None
+        assert asset.docker_image_asset.node.scope is asset
+
+    def test__from_registry__records_the_container_image_source(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(
+            image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda", tag="v1.2.3"
+        )
+        asset = DockerAsset.from_registry(stack, "Image", source)
+        assert asset.source is source
+        assert asset.docker_image_asset is None
+
+    def test__from_registry__accepts_a_bare_image_uri(self):
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        assert asset.source is None
+        assert asset.image_uri == IMAGE_URI
+
+
+# ---------------------------------------------------------------------------
+# DockerAsset.from_source
+# ---------------------------------------------------------------------------
+
+
+class TestDockerAssetFromSource(DockerAssetBaseTest):
+    def test__from_source__container_image_source_resolves_to_the_registry(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(
+            image="ghcr.io/alleninstitute/aibs-informatics-aws-lambda", tag="v1.2.3"
+        )
+        asset = DockerAsset.from_source(stack, "Image", source)
+        assert asset.docker_image_asset is None
+        assert asset.image_uri == IMAGE_URI
+
+    def test__from_source__container_image_source_ignores_a_directory(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(image="ghcr.io/org/repo", tag="v1")
+        asset = DockerAsset.from_source(
+            stack, "Image", source, directory=self.build_context().as_posix()
+        )
+        assert asset.docker_image_asset is None
+
+    def test__from_source__git_source_builds_from_the_directory(self):
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        asset = DockerAsset.from_source(
+            stack,
+            "Image",
+            source,
+            directory=self.build_context().as_posix(),
+            file="docker/Dockerfile",
+        )
+        assert asset.docker_image_asset is not None
+        assert asset.source is source
+
+    def test__from_source__git_source_without_a_directory_raises(self):
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git")
+        with pytest.raises(ValueError, match="without a `directory`"):
+            DockerAsset.from_source(stack, "Image", source)
+
+
+# ---------------------------------------------------------------------------
+# URI accessors
+# ---------------------------------------------------------------------------
+
+
+class TestDockerAssetUris(DockerAssetBaseTest):
+    def test__local_build__all_uris_are_the_built_asset_uri(self):
+        asset = self.local_build_asset()
+        assert asset.docker_image_asset is not None
+        built_uri = asset.docker_image_asset.image_uri
+        assert asset.image_uri == built_uri
+        assert asset.source_image_uri == built_uri
+        assert asset.ecr_image_uri == built_uri
+
+    def test__registry__source_uri_is_the_registry_uri_and_ecr_uri_is_none(self):
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        assert asset.source_image_uri == IMAGE_URI
+        assert asset.ecr_image_uri is None
+
+    def test__registry__image_uri_falls_back_to_the_origin_registry(self):
+        """Until the image is mirrored, the origin registry is the most-local URI there is."""
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        assert asset.image_uri == asset.source_image_uri
+
+
+# ---------------------------------------------------------------------------
+# Per-service representations
+# ---------------------------------------------------------------------------
+
+
+class TestDockerAssetAsEcsImage(DockerAssetBaseTest):
+    def test__as_ecs_image__local_build_uses_the_image_asset(self):
+        asset = self.local_build_asset()
+        with patch.object(ecs.ContainerImage, "from_docker_image_asset") as mock_from_asset:
+            result = asset.as_ecs_image()
+        mock_from_asset.assert_called_once_with(asset.docker_image_asset)
+        assert result is mock_from_asset.return_value
+
+    def test__as_ecs_image__registry_pulls_directly(self):
+        """ECS can pull a public registry itself, so no mirror is required."""
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        with patch.object(ecs.ContainerImage, "from_registry") as mock_from_registry:
+            result = asset.as_ecs_image()
+        mock_from_registry.assert_called_once_with(IMAGE_URI)
+        assert result is mock_from_registry.return_value
+
+    def test__as_ecs_image__returns_a_container_image(self):
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        assert isinstance(asset.as_ecs_image(), ecs.ContainerImage)
+
+
+class TestDockerAssetAsLambdaCode(DockerAssetBaseTest):
+    def test__as_lambda_code__local_build_points_at_the_asset_repository(self):
+        asset = self.local_build_asset()
+        image_asset = asset.docker_image_asset
+        assert image_asset is not None
+        with patch.object(lambda_.DockerImageCode, "from_ecr") as mock_from_ecr:
+            result = asset.as_lambda_code()
+        # jsii hands back a fresh proxy on every property read, so compare by name.
+        (repository,), kwargs = mock_from_ecr.call_args
+        assert repository.repository_name == image_asset.repository.repository_name
+        assert kwargs == {"tag_or_digest": image_asset.image_tag}
+        assert result is mock_from_ecr.return_value
+
+    def test__as_lambda_code__local_build_returns_docker_image_code(self):
+        asset = self.local_build_asset()
+        assert isinstance(asset.as_lambda_code(), lambda_.DockerImageCode)
+
+    def test__as_lambda_code__unmirrored_registry_raises(self):
+        """Lambda container images must live in ECR; mirroring is the fix, not a fallback."""
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        with pytest.raises(ValueError, match="mirror_to_ecr=True"):
+            asset.as_lambda_code()
+
+    def test__as_lambda_code__error_names_the_offending_image(self):
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        with pytest.raises(ValueError, match=IMAGE_URI):
+            asset.as_lambda_code()
+
+    def test__as_lambda_code__does_not_create_infrastructure_on_failure(self):
+        """A property access must never provision an ECR repository as a side effect."""
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        with pytest.raises(ValueError):
+            asset.as_lambda_code()
+        assert asset.node.children == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_image_uri
+# ---------------------------------------------------------------------------
+
+
+class TestResolveImageUri(DockerAssetBaseTest):
+    def test__resolve_image_uri__str_passes_through(self):
+        assert resolve_image_uri(IMAGE_URI) == IMAGE_URI
+
+    def test__resolve_image_uri__docker_asset(self):
+        stack = self.get_dummy_stack("test")
+        asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        assert resolve_image_uri(asset) == IMAGE_URI
+
+    def test__resolve_image_uri__raw_docker_image_asset(self):
+        """Downstream Assets Constructs still expose raw CDK assets; they must keep working."""
+        stack = self.get_dummy_stack("test")
+        image_asset = ecr_assets.DockerImageAsset(
+            stack,
+            "RawImage",
+            directory=self.build_context().as_posix(),
+            file="docker/Dockerfile",
+        )
+        assert resolve_image_uri(image_asset) == image_asset.image_uri

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_source.py
@@ -294,6 +294,12 @@ class TestPackageSourceFromStr:
         with pytest.raises(ValueError, match="Cannot parse"):
             PackageSource.from_str("not-a-valid-source")
 
+    def test__from_str__container_image_does_not_print_git_errors(self, capfd):
+        """Image refs are probed as local repo paths first; that must not pollute stderr."""
+        source = PackageSource.from_str("ghcr.io/org/repo:latest")
+        assert isinstance(source, ContainerImageSource)
+        assert capfd.readouterr().err == ""
+
     def test__from_str__local_repo(self, tmp_path):
         """Local git repos should parse as GitSource."""
         # Initialize a git repo in the temp directory


### PR DESCRIPTION
**Stack 2 of 3** — base is #57, review that first. Part of [DT-9926](https://alleninstitute.atlassian.net/browse/DT-9926).

## Why a per-asset construct

Each AWS service consumes an image differently — Batch wants a URI string, ECS wants an `ecs.ContainerImage`, Lambda wants a `lambda_.DockerImageCode`. The obvious home for those is properties on `AIBSInformaticsDockerAssets`, but that construct is a **namespace**: five downstream repos (`gcs`, `ocs`, `ocs-deploy`, `transcriptomics-alignment`, `merscope-analysis-cloud-pipeline`) subclass it and add their own `cached_property` members for their own images. A per-representation property on a namespace can only ever describe one asset in it.

So the representations move to a construct representing one image. Rationale recorded in `docs/adr/0001-docker-asset-is-its-own-construct.md`.

## Changes

- **`DockerAsset`** — built locally from a `GitSource` or resolved from a `ContainerImageSource`. Factories `from_source()`, `from_local_build()`, `from_registry()`; accessors `image_uri`, `source_image_uri`, `ecr_image_uri`, `as_ecs_image()`, `as_lambda_code()`.
- It is a `Construct` rather than a value object specifically so it can own child constructs — which is what makes the opt-in ECR mirroring in stack 3 possible.
- `as_lambda_code()` **raises** on an unmirrored registry source, naming `mirror_to_ecr=True` as the fix. This is an AWS constraint, not a gap: Lambda container images must live in ECR, and `DockerImageCode` offers only `from_ecr()` and `from_image_asset()`. It deliberately does *not* auto-provision an ECR repo — a property access must never create infrastructure.
- `AIBS_INFORMATICS_AWS_LAMBDA` returns a `DockerAsset`. Local-build behaviour is preserved verbatim: `generate_path_hash` → `extra_hash`, `build_ssh="default"`, `LINUX_AMD64`, `file="docker/Dockerfile"`, both exclude lists.
- **`DockerAssetLike` + `resolve_image_uri()`** applied across `data_sync.py`, `efs.py`, `demand_execution.py`, deleting eight duplicated `isinstance(x, str) → x, else x.image_uri` ternaries.
- `is_local_repo` now suppresses subprocess stderr. Parsing `ghcr.io/org/repo:latest` printed `fatal: cannot change to 'ghcr.io/...'` on every synth, because the git check runs before the image regex.
- `CONTEXT.md` glossary and both ADRs. ADR-0002 documents the mirroring decision that stack 3 implements — the decision precedes the code by design.

## Compatibility — verified, not assumed

Eight downstream call sites pass this property straight into the fragments; all keep working untouched, since `DockerAsset` exposes `.image_uri` and satisfies the existing narrowing path. Downstream subclasses returning raw `ecr_assets.DockerImageAsset` also keep working through the same fragments. Confirmed by type-checking a scratch file reproducing both shapes against all seven fragment entry points.

**One thing for reviewers:** the `DockerImageAsset` moves to `…/DockerAssets/aibs-informatics-aws-lambda/Image`. Deployment output is unaffected — an image tag is a content hash, not a construct path — but the asset's key in the `cdk.out` manifest changes.

## Verification

`224 passed` (196 on #57), `ruff check` and `ruff format --check` clean, `mypy` clean on the assets package checked explicitly.

Two new tests genuinely shell out to `git` rather than mocking: they assert that parsing a `ghcr.io/…` ref prints *nothing* to stderr, which a mock cannot demonstrate. Local-only, no network, and the mocked white-box counterpart is present alongside.

[DT-9926]: https://alleninstitute.atlassian.net/browse/DT-9926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ