### PR TITLE
DT-9928 (3/3): opt-in ECR mirroring with synth-time digest pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,23 @@ dependencies = [
     "pydantic~=2.0",
 ]
 
+# Optional extras. Keep these OUT of `dependencies` -- `gcs`, `ocs`, and `ocs-deploy` all
+# pin `cdk-ecr-deployment~=3.1.13` while upstream supports only v4, so a hard dependency on
+# either major makes those repos unresolvable the moment they bump. Mirroring is opt-in per
+# Docker Asset, so its dependency is opt-in too, imported lazily where it is used.
+[project.optional-dependencies]
+ecr-mirror = [
+    "cdk-ecr-deployment>=3.1,<5",
+]
+
 # For dev dependencies: https://peps.python.org/pep-0735/
 # See also: https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups
 [dependency-groups]
 dev = [
     "aibs-informatics-test-resources[all]~=0.0.4",
+    # Not a runtime dependency (see `[project.optional-dependencies]`), but installed for
+    # tests so CI exercises the ECR mirroring path instead of skipping it.
+    "cdk-ecr-deployment>=3.1,<5",
 ]
 lint = [
     "boto3-stubs[s3,batch]",

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/docker_asset.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/docker_asset.py
@@ -6,27 +6,45 @@ representations belong to a single image, not to the Assets Construct that colle
 several of them, so they hang off ``DockerAsset``.
 
 ``DockerAsset`` is a ``constructs.Construct`` rather than a plain value object so that it
-can own child constructs -- today the ``DockerImageAsset`` it builds, later the ECR
-repository and deployment used to mirror a Container Image Source in-region.
+can own child constructs -- the ``DockerImageAsset`` it builds, and the ECR repository and
+deployments used to mirror a Container Image Source in-region.
 """
 
 import logging
+import re
+from collections.abc import Sequence
 from typing import Any
 
+import aws_cdk as cdk
 import constructs
+from aibs_informatics_core.env import EnvBase
+from aws_cdk import aws_ecr as ecr
 from aws_cdk import aws_ecr_assets as ecr_assets
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_lambda as lambda_
 
+from aibs_informatics_cdk_lib.constructs_.assets.registry import (
+    DEFAULT_TAG,
+    digest_to_tag,
+    parse_image_reference,
+    resolve_image_digest,
+)
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
     PackageSource,
 )
+from aibs_informatics_cdk_lib.project.utils import get_env_base
 
 logger = logging.getLogger(__name__)
 
 IMAGE_CONSTRUCT_ID = "Image"
 """Construct id of the ``DockerImageAsset`` a locally built ``DockerAsset`` owns."""
+
+MIRROR_REPOSITORY_CONSTRUCT_ID = "MirrorRepository"
+"""Construct id of the ECR repository a ``DockerAsset`` creates to mirror into."""
+
+MIRROR_CONSTRUCT_ID_PREFIX = "Mirror"
+"""Construct id prefix of the ``ECRDeployment`` copying an image to one destination tag."""
 
 
 class DockerAsset(constructs.Construct):
@@ -45,6 +63,10 @@ class DockerAsset(constructs.Construct):
         directory: str | None = None,
         registry_image_uri: str | None = None,
         source: PackageSource | None = None,
+        mirror_to_ecr: bool = False,
+        ecr_repository: ecr.IRepository | None = None,
+        mirror_tags: Sequence[str] | None = None,
+        pin_digest: bool = False,
         **image_asset_props: Any,
     ) -> None:
         """Create a Docker Asset from exactly one of a build context or a registry URI.
@@ -57,14 +79,32 @@ class DockerAsset(constructs.Construct):
             registry_image_uri: The URI of a pre-built image in a registry. Mutually
                 exclusive with ``directory``.
             source: The Source this image was produced from, recorded for provenance.
+            mirror_to_ecr: Copy the registry image into an ECR repository at deploy time so
+                workloads pull in-region. Requires the ``ecr-mirror`` extra, and resolves
+                the source tag to its digest at synth -- see ``pin_digest``.
+            ecr_repository: The repository to mirror into. Defaults to one this construct
+                creates, named ``{env_base}-{asset_name}`` and retained on stack deletion.
+                Only valid alongside ``mirror_to_ecr``.
+            mirror_tags: The destination tags to publish the mirrored image under, one
+                ``ECRDeployment`` each. Defaults to an immutable ``sha256-<hex>`` tag plus
+                the source tag as a moving alias. Only valid alongside ``mirror_to_ecr``.
+            pin_digest: Resolve the source tag to its immutable digest and reference the
+                image by that digest, for direct pull as well as mirroring. Off by default
+                so that direct pull keeps following the mutable tag. Mirroring pins
+                regardless, because a mirror of a mutable tag would freeze on first deploy.
             **image_asset_props: Additional props forwarded to
                 ``aws_ecr_assets.DockerImageAsset`` (e.g. ``file``, ``platform``,
                 ``build_ssh``, ``asset_name``, ``extra_hash``, ``exclude``). Only valid
                 alongside ``directory``.
 
         Raises:
-            ValueError: If neither or both of ``directory`` and ``registry_image_uri``
-                are given, or if image asset props are given without a ``directory``.
+            ValueError: If neither or both of ``directory`` and ``registry_image_uri`` are
+                given, if image asset props or registry-only options are given for the
+                wrong one of the two, or if a mirror option is given without
+                ``mirror_to_ecr``.
+            ImportError: If ``mirror_to_ecr`` is set without the ``ecr-mirror`` extra.
+            DigestResolutionError: If the source tag has to be resolved to a digest and the
+                registry cannot be reached.
         """
         super().__init__(scope, id)
 
@@ -78,6 +118,19 @@ class DockerAsset(constructs.Construct):
                 f"Docker image asset props {sorted(image_asset_props)} are only valid when "
                 "building from a `directory`."
             )
+        if directory is not None and (
+            mirror_to_ecr or pin_digest or ecr_repository is not None or mirror_tags is not None
+        ):
+            raise ValueError(
+                "Mirroring and digest pinning apply to a `registry_image_uri`. An image "
+                "built from a `directory` is already published to the CDK asset repository "
+                "in ECR, and its digest is only known after the build."
+            )
+        if not mirror_to_ecr and (ecr_repository is not None or mirror_tags is not None):
+            raise ValueError(
+                "`ecr_repository` and `mirror_tags` configure a mirror, so they do nothing "
+                "unless `mirror_to_ecr=True` is also passed."
+            )
 
         self._source = source
         self._registry_image_uri = registry_image_uri
@@ -88,6 +141,24 @@ class DockerAsset(constructs.Construct):
             if directory is not None
             else None
         )
+        self._mirror_repository: ecr.IRepository | None = None
+        self._mirror_tags: tuple[str, ...] = ()
+
+        if registry_image_uri is not None and (mirror_to_ecr or pin_digest):
+            image_name, tag, digest = parse_image_reference(registry_image_uri)
+            # An explicitly pinned digest is already the answer, so skip the network and
+            # keep synth offline-capable.
+            digest = digest or resolve_image_digest(image_name, tag or DEFAULT_TAG)
+            if pin_digest:
+                self._registry_image_uri = f"{image_name}@{digest}"
+            if mirror_to_ecr:
+                self._mirror(
+                    image_name=image_name,
+                    tag=tag,
+                    digest=digest,
+                    ecr_repository=ecr_repository,
+                    mirror_tags=mirror_tags,
+                )
 
     # -----------------------------------------------------------------------------
     # Factories
@@ -101,6 +172,10 @@ class DockerAsset(constructs.Construct):
         source: PackageSource,
         *,
         directory: str | None = None,
+        mirror_to_ecr: bool = False,
+        ecr_repository: ecr.IRepository | None = None,
+        mirror_tags: Sequence[str] | None = None,
+        pin_digest: bool = False,
         **image_asset_props: Any,
     ) -> "DockerAsset":
         """Create a Docker Asset from a Source, building or resolving as the Source requires.
@@ -115,6 +190,14 @@ class DockerAsset(constructs.Construct):
             source: The Source to produce the image from.
             directory: The docker build context. Required for a Git Source, ignored for
                 a Container Image Source.
+            mirror_to_ecr: Mirror the image into ECR. Only valid for a Container Image
+                Source; see ``DockerAsset.__init__``.
+            ecr_repository: The repository to mirror into. Only valid for a Container Image
+                Source; see ``DockerAsset.__init__``.
+            mirror_tags: The destination tags for the mirror. Only valid for a Container
+                Image Source; see ``DockerAsset.__init__``.
+            pin_digest: Reference the image by its resolved digest. Only valid for a
+                Container Image Source; see ``DockerAsset.__init__``.
             **image_asset_props: Additional props forwarded to
                 ``aws_ecr_assets.DockerImageAsset``.
 
@@ -122,10 +205,25 @@ class DockerAsset(constructs.Construct):
             A Docker Asset for the given Source.
 
         Raises:
-            ValueError: If the Source must be built but no ``directory`` was given.
+            ValueError: If the Source must be built but no ``directory`` was given, or if a
+                registry-only option was given for a Source that has to be built.
         """
         if isinstance(source, ContainerImageSource):
-            return cls.from_registry(scope, id, source)
+            return cls.from_registry(
+                scope,
+                id,
+                source,
+                mirror_to_ecr=mirror_to_ecr,
+                ecr_repository=ecr_repository,
+                mirror_tags=mirror_tags,
+                pin_digest=pin_digest,
+            )
+        if mirror_to_ecr or pin_digest or ecr_repository is not None or mirror_tags is not None:
+            raise ValueError(
+                f"Mirroring and digest pinning are not available for {type(source).__name__}: "
+                "an image built from a checkout is already published to the CDK asset "
+                "repository in ECR."
+            )
         if directory is None:
             raise ValueError(
                 f"Cannot build a Docker Asset from {type(source).__name__} without a "
@@ -167,6 +265,11 @@ class DockerAsset(constructs.Construct):
         scope: constructs.Construct,
         id: str,
         image: ContainerImageSource | str,
+        *,
+        mirror_to_ecr: bool = False,
+        ecr_repository: ecr.IRepository | None = None,
+        mirror_tags: Sequence[str] | None = None,
+        pin_digest: bool = False,
     ) -> "DockerAsset":
         """Create a Docker Asset from an image that is already published to a registry.
 
@@ -174,13 +277,120 @@ class DockerAsset(constructs.Construct):
             scope: The parent construct.
             id: The construct id.
             image: A Container Image Source, or an image URI string.
+            mirror_to_ecr: Mirror the image into ECR; see ``DockerAsset.__init__``.
+            ecr_repository: The repository to mirror into; see ``DockerAsset.__init__``.
+            mirror_tags: The destination tags for the mirror; see ``DockerAsset.__init__``.
+            pin_digest: Reference the image by its resolved digest; see
+                ``DockerAsset.__init__``.
 
         Returns:
             A Docker Asset referencing the published image.
         """
+        source: ContainerImageSource | None = None
+        registry_image_uri: str
         if isinstance(image, ContainerImageSource):
-            return cls(scope, id, registry_image_uri=image.image_uri, source=image)
-        return cls(scope, id, registry_image_uri=image)
+            source, registry_image_uri = image, image.image_uri
+        else:
+            registry_image_uri = image
+        return cls(
+            scope,
+            id,
+            registry_image_uri=registry_image_uri,
+            source=source,
+            mirror_to_ecr=mirror_to_ecr,
+            ecr_repository=ecr_repository,
+            mirror_tags=mirror_tags,
+            pin_digest=pin_digest,
+        )
+
+    # -----------------------------------------------------------------------------
+    # Mirroring
+    # -----------------------------------------------------------------------------
+
+    def _mirror(
+        self,
+        *,
+        image_name: str,
+        tag: str | None,
+        digest: str,
+        ecr_repository: ecr.IRepository | None,
+        mirror_tags: Sequence[str] | None,
+    ) -> None:
+        """Wire up the ECR repository and deployments that copy this image in-region.
+
+        Args:
+            image_name: The source image name, including its registry host.
+            tag: The source tag, if the reference carried one.
+            digest: The resolved content digest of the image to copy.
+            ecr_repository: The repository to mirror into, or None to create one.
+            mirror_tags: The destination tags, or None for the default pair.
+
+        Raises:
+            ValueError: If ``mirror_tags`` is empty.
+            ImportError: If the ``ecr-mirror`` extra is not installed.
+        """
+        docker_image_name, ecr_deployment = _import_ecr_deployment()
+
+        tags = tuple(mirror_tags) if mirror_tags is not None else _default_mirror_tags(digest, tag)
+        if not tags:
+            raise ValueError("`mirror_tags` must name at least one destination tag to copy to.")
+
+        repository = ecr_repository or self._create_mirror_repository(image_name)
+        # Copy from the digest, never the tag: the custom resource reruns only when its
+        # properties change, and a tag's properties do not change when the tag moves.
+        source_uri = f"{image_name}@{digest}"
+        for mirror_tag in tags:
+            ecr_deployment(
+                self,
+                f"{MIRROR_CONSTRUCT_ID_PREFIX}{_construct_id_fragment(mirror_tag)}",
+                src=docker_image_name(source_uri),
+                dest=docker_image_name(repository.repository_uri_for_tag(mirror_tag)),
+            )
+
+        self._mirror_repository = repository
+        self._mirror_tags = tags
+
+    def _create_mirror_repository(self, image_name: str) -> ecr.IRepository:
+        """Create the ECR repository this image is mirrored into.
+
+        Args:
+            image_name: The source image name, whose last path segment names the asset.
+
+        Returns:
+            A repository named ``{env_base}-{asset_name}``, retained on stack deletion so
+            that tearing down a stack never deletes images other stacks may still pull.
+        """
+        asset_name = image_name.rsplit("/", 1)[-1]
+        return ecr.Repository(
+            self,
+            MIRROR_REPOSITORY_CONSTRUCT_ID,
+            repository_name=f"{self._resolve_env_base()}-{asset_name}".lower(),
+            removal_policy=cdk.RemovalPolicy.RETAIN,
+        )
+
+    def _resolve_env_base(self) -> EnvBase:
+        """Find the environment this asset is being deployed into.
+
+        Returns:
+            The nearest ``EnvBase`` in scope, falling back to CDK context or environment.
+
+        Raises:
+            ValueError: If no environment can be resolved, since the default repository
+                name is built from it.
+        """
+        for scope in reversed(self.node.scopes):
+            env_base = getattr(scope, "env_base", None)
+            if isinstance(env_base, EnvBase):
+                return env_base
+        try:
+            return get_env_base(self.node)
+        except Exception as e:
+            raise ValueError(
+                f"Cannot name an ECR repository to mirror '{self.node.path}' into: no "
+                "EnvBase is in scope. Place this asset under an EnvBaseStack or "
+                "EnvBaseConstruct, set the env base in CDK context, or pass "
+                "`ecr_repository` to mirror into a repository you name yourself."
+            ) from e
 
     # -----------------------------------------------------------------------------
     # Accessors
@@ -195,6 +405,16 @@ class DockerAsset(constructs.Construct):
     def docker_image_asset(self) -> ecr_assets.DockerImageAsset | None:
         """The underlying CDK asset for a locally built image, or None for a registry image."""
         return self._image_asset
+
+    @property
+    def mirror_repository(self) -> ecr.IRepository | None:
+        """The ECR repository this image is mirrored into, or None if it is not mirrored."""
+        return self._mirror_repository
+
+    @property
+    def mirror_tags(self) -> tuple[str, ...]:
+        """The destination tags the mirror publishes, most specific first, or empty."""
+        return self._mirror_tags
 
     @property
     def image_uri(self) -> str:
@@ -212,9 +432,9 @@ class DockerAsset(constructs.Construct):
     def source_image_uri(self) -> str:
         """The URI of this image where its Source puts it.
 
-        For a Container Image Source that is the origin registry. For a locally built
-        image there is no upstream registry, so it is the URI CDK publishes the built
-        asset to.
+        For a Container Image Source that is the origin registry, digest-pinned when
+        ``pin_digest`` asked for it. For a locally built image there is no upstream
+        registry, so it is the URI CDK publishes the built asset to.
 
         Returns:
             The image URI at its origin.
@@ -229,15 +449,17 @@ class DockerAsset(constructs.Construct):
         """The URI of this image inside an ECR repository, or None if it is not in one.
 
         A locally built image is published to the CDK asset repository, which is ECR. An
-        image resolved from a Container Image Source stays at its origin registry until
-        it is mirrored into ECR, which this construct does not yet do.
+        image resolved from a Container Image Source stays at its origin registry until it
+        is mirrored, and then it is in the mirror repository under the first mirror tag --
+        the immutable digest tag, by default.
 
         Returns:
             The in-ECR image URI, or None when the image is only at its origin registry.
         """
-        # NOTE: mirroring a Container Image Source into ECR resolves the None case.
         if self._image_asset is not None:
             return self._image_asset.image_uri
+        if self._mirror_repository is not None:
+            return self._mirror_repository.repository_uri_for_tag(self._mirror_tags[0])
         return None
 
     def as_ecs_image(self) -> ecs.ContainerImage:
@@ -251,6 +473,12 @@ class DockerAsset(constructs.Construct):
         """
         if self._image_asset is not None:
             return ecs.ContainerImage.from_docker_image_asset(self._image_asset)
+        if self._mirror_repository is not None:
+            # from_registry would produce the same URI but grant the execution role no
+            # pull permission on the repository we just created.
+            return ecs.ContainerImage.from_ecr_repository(
+                self._mirror_repository, tag=self._mirror_tags[0]
+            )
         return ecs.ContainerImage.from_registry(self.image_uri)
 
     def as_lambda_code(self) -> lambda_.DockerImageCode:
@@ -267,17 +495,76 @@ class DockerAsset(constructs.Construct):
                 infrastructure as a side effect of reading a property, so it has to be
                 asked for explicitly.
         """
-        # NOTE: mirroring a Container Image Source into ECR gives this the repository and
-        # tag it needs, and the `from_ecr` call below serves that case unchanged.
-        if self._image_asset is None:
-            raise ValueError(
-                f"Cannot use '{self.source_image_uri}' as Lambda code: Lambda container "
-                "images must live in ECR, and this image is only available at its origin "
-                "registry. Pass `mirror_to_ecr=True` for this asset to copy it into ECR."
+        if self._image_asset is not None:
+            return lambda_.DockerImageCode.from_ecr(
+                self._image_asset.repository, tag_or_digest=self._image_asset.image_tag
             )
-        return lambda_.DockerImageCode.from_ecr(
-            self._image_asset.repository, tag_or_digest=self._image_asset.image_tag
+        if self._mirror_repository is not None:
+            return lambda_.DockerImageCode.from_ecr(
+                self._mirror_repository, tag_or_digest=self._mirror_tags[0]
+            )
+        raise ValueError(
+            f"Cannot use '{self.source_image_uri}' as Lambda code: Lambda container "
+            "images must live in ECR, and this image is only available at its origin "
+            "registry. Pass `mirror_to_ecr=True` for this asset to copy it into ECR."
         )
+
+
+def _default_mirror_tags(digest: str, tag: str | None) -> tuple[str, ...]:
+    """Build the destination tags a mirror publishes when the caller names none.
+
+    An immutable digest tag so a workload can name one exact image forever, plus the source
+    tag as a moving alias so ``:latest`` in ECR keeps meaning what it means upstream.
+
+    Args:
+        digest: The resolved content digest of the image being mirrored.
+        tag: The source tag, if the reference carried one.
+
+    Returns:
+        The destination tags, immutable one first.
+    """
+    tags = [digest_to_tag(digest)]
+    if tag is not None and tag not in tags:
+        tags.append(tag)
+    return tuple(tags)
+
+
+def _construct_id_fragment(value: str) -> str:
+    """Reduce a tag to something usable inside a construct id.
+
+    Args:
+        value: The tag to reduce.
+
+    Returns:
+        The tag with every non-alphanumeric character removed.
+    """
+    return re.sub(r"[^A-Za-z0-9]+", "", value)
+
+
+def _import_ecr_deployment() -> tuple[Any, Any]:
+    """Import the optional ``cdk-ecr-deployment`` package, lazily.
+
+    Mirroring is opt-in per Docker Asset, so its dependency is opt-in too: ``gcs``, ``ocs``,
+    and ``ocs-deploy`` all pin ``cdk-ecr-deployment~=3.1.13`` while upstream supports only
+    v4, and a hard dependency on either major would make those repos unresolvable.
+
+    Returns:
+        The ``DockerImageName`` and ``ECRDeployment`` classes.
+
+    Raises:
+        ImportError: If ``cdk-ecr-deployment`` is not installed, naming the extra.
+    """
+    try:
+        from cdk_ecr_deployment import DockerImageName, ECRDeployment
+    except ImportError as e:
+        raise ImportError(
+            "Mirroring a Docker Asset into ECR needs `cdk-ecr-deployment`, which is an "
+            "optional dependency of aibs-informatics-cdk-lib. Install it with the "
+            "`ecr-mirror` extra (e.g. `pip install 'aibs-informatics-cdk-lib[ecr-mirror]'` "
+            "or `uv add 'aibs-informatics-cdk-lib[ecr-mirror]'`), or drop `mirror_to_ecr` "
+            "and pull the image directly from its origin registry."
+        ) from e
+    return DockerImageName, ECRDeployment
 
 
 DockerAssetLike = ecr_assets.DockerImageAsset | DockerAsset | str

--- a/src/aibs_informatics_cdk_lib/constructs_/assets/registry.py
+++ b/src/aibs_informatics_cdk_lib/constructs_/assets/registry.py
@@ -1,0 +1,193 @@
+"""Digest Pinning -- resolving a mutable container image tag to its content digest.
+
+A Mirror is a CloudFormation custom resource, and CloudFormation invokes one only when its
+properties change. Mirroring ``:latest`` to ``:latest`` would therefore copy the image once
+at first deploy and then freeze the ECR copy forever while ``latest`` moved on upstream.
+Resolving the tag to its immutable digest at synth time is what makes the mirror's
+properties change whenever the upstream image does, so mirroring requires it.
+
+The lookup is two anonymous requests against the OCI Distribution API -- a pull-scoped
+token, then a manifest ``HEAD`` -- issued with stdlib ``urllib`` so that Digest Pinning
+costs no runtime dependency. The ``Accept`` header lists the index media types as well as
+the single-manifest one, so a multi-platform image resolves to its image index digest; that
+is the correct thing to pin and to mirror, because the per-platform child is selected at
+pull time.
+
+Auth is pluggable via ``auth_header`` so a token can be supplied if the package ever goes
+private, but no credential plumbing exists today -- see ADR 0002.
+"""
+
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TAG = "latest"
+"""The tag an image reference means when it names none."""
+
+DIGEST_HEADER = "Docker-Content-Digest"
+"""The manifest response header carrying the content digest."""
+
+MANIFEST_MEDIA_TYPES = (
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+)
+"""Manifest media types to accept, multi-platform indexes first."""
+
+DEFAULT_TIMEOUT: float = 10.0
+"""Seconds to wait on each registry request before giving up."""
+
+AuthHeaderProvider = Callable[[str, str], str | None]
+"""Builds the ``Authorization`` header value for a ``(registry, repository)`` pair.
+
+Returning ``None`` sends the manifest request unauthenticated.
+"""
+
+
+class DigestResolutionError(RuntimeError):
+    """Raised when a container image tag cannot be resolved to a content digest."""
+
+
+def parse_image_reference(image_uri: str) -> tuple[str, str | None, str | None]:
+    """Split a container image URI into its name, tag, and digest.
+
+    A colon only introduces a tag when it comes after the last ``/``; before that it is a
+    registry port.
+
+    Args:
+        image_uri: An image reference such as ``ghcr.io/org/repo:v1`` or
+            ``ghcr.io/org/repo@sha256:abc123``.
+
+    Returns:
+        A ``(name, tag, digest)`` tuple, where ``name`` includes the registry host and
+        ``tag`` and ``digest`` are None when the reference does not carry them.
+    """
+    name, _, digest = image_uri.partition("@")
+    head, separator, candidate_tag = name.rpartition(":")
+    tag = None
+    if separator and "/" not in candidate_tag:
+        name, tag = head, candidate_tag
+    return name, tag or None, digest or None
+
+
+def digest_to_tag(digest: str) -> str:
+    """Convert a content digest into a tag that ECR will accept.
+
+    ``:`` is illegal in an image tag, so ``sha256:abc123`` becomes ``sha256-abc123``.
+
+    Args:
+        digest: A content digest, e.g. ``sha256:abc123``.
+
+    Returns:
+        The digest rendered as a legal tag.
+    """
+    return digest.replace(":", "-")
+
+
+def resolve_image_digest(
+    image_name: str,
+    tag: str = DEFAULT_TAG,
+    *,
+    auth_header: AuthHeaderProvider | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> str:
+    """Resolve a container image tag to the content digest it currently points at.
+
+    Args:
+        image_name: The image name including its registry host, e.g.
+            ``ghcr.io/alleninstitute/aibs-informatics-aws-lambda``.
+        tag: The tag to resolve. Defaults to ``latest``.
+        auth_header: Builds the ``Authorization`` header for the manifest request. Defaults
+            to fetching an anonymous pull-scoped token from the registry.
+        timeout: Seconds to wait on each registry request.
+
+    Returns:
+        The content digest, e.g. ``sha256:abc123``.
+
+    Raises:
+        DigestResolutionError: If the registry is unreachable, refuses the request, or
+            answers without a digest header. Never falls back to the mutable tag.
+    """
+    registry, _, repository = image_name.partition("/")
+    if not repository:
+        raise _resolution_error(image_name, tag, "the reference names no registry host to ask")
+
+    provider = auth_header or (lambda reg, repo: _anonymous_auth_header(reg, repo, timeout))
+    try:
+        header = provider(registry, repository)
+        request = urllib.request.Request(
+            f"https://{registry}/v2/{repository}/manifests/{tag}",
+            method="HEAD",
+            headers={"Accept": ", ".join(MANIFEST_MEDIA_TYPES)},
+        )
+        if header:
+            request.add_header("Authorization", header)
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            digest = response.headers.get(DIGEST_HEADER)
+    except DigestResolutionError:
+        raise
+    except (OSError, ValueError) as e:
+        raise _resolution_error(image_name, tag, f"{type(e).__name__}: {e}") from e
+
+    if not digest:
+        raise _resolution_error(
+            image_name, tag, f"the registry answered without a {DIGEST_HEADER} header"
+        )
+
+    logger.debug("Resolved %s:%s to %s", image_name, tag, digest)
+    return digest
+
+
+def _anonymous_auth_header(registry: str, repository: str, timeout: float) -> str | None:
+    """Fetch an anonymous pull-scoped bearer token for a repository.
+
+    Args:
+        registry: The registry host, e.g. ``ghcr.io``.
+        repository: The repository path within the registry, e.g. ``org/repo``.
+        timeout: Seconds to wait on the token request.
+
+    Returns:
+        The ``Authorization`` header value.
+
+    Raises:
+        DigestResolutionError: If the registry issues no token.
+    """
+    scope = urllib.parse.quote(f"repository:{repository}:pull", safe=":/")
+    token_url = f"https://{registry}/token?scope={scope}&service={registry}"
+    with urllib.request.urlopen(urllib.request.Request(token_url), timeout=timeout) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+
+    token = payload.get("token") or payload.get("access_token")
+    if not token:
+        raise DigestResolutionError(
+            f"Registry '{registry}' issued no anonymous pull token for '{repository}'. "
+            "The package is probably private; this library builds no credential plumbing, "
+            "so pin the digest explicitly instead."
+        )
+    return f"Bearer {token}"
+
+
+def _resolution_error(image_name: str, tag: str, reason: str) -> DigestResolutionError:
+    """Build the hard error raised when a tag cannot be resolved.
+
+    Args:
+        image_name: The image name that failed to resolve.
+        tag: The tag that failed to resolve.
+        reason: What went wrong, phrased to follow a colon.
+
+    Returns:
+        The error to raise, naming the fix.
+    """
+    return DigestResolutionError(
+        f"Could not resolve '{image_name}:{tag}' to a content digest: {reason}. "
+        "A mirror must be digest-pinned -- CloudFormation would otherwise copy the tag "
+        "once and never notice it moving -- so this cannot silently fall back to the "
+        f"mutable tag. Pin the digest explicitly ('{image_name}@sha256:<hex>') to skip "
+        "this lookup and keep synth offline-capable, or give synth network access to "
+        f"'{image_name.partition('/')[0]}'."
+    )

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_docker_asset.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_docker_asset.py
@@ -1,7 +1,10 @@
+import importlib.util
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from aws_cdk import aws_ecr as ecr
 from aws_cdk import aws_ecr_assets as ecr_assets
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_lambda as lambda_
@@ -10,13 +13,40 @@ from aibs_informatics_cdk_lib.constructs_.assets.docker_asset import (
     DockerAsset,
     resolve_image_uri,
 )
+from aibs_informatics_cdk_lib.constructs_.assets.registry import DigestResolutionError
 from aibs_informatics_cdk_lib.constructs_.assets.source import (
     ContainerImageSource,
     GitSource,
 )
 from test.aibs_informatics_cdk_lib.base import CdkBaseTest
 
-IMAGE_URI = "ghcr.io/alleninstitute/aibs-informatics-aws-lambda:v1.2.3"
+IMAGE_NAME = "ghcr.io/alleninstitute/aibs-informatics-aws-lambda"
+IMAGE_URI = f"{IMAGE_NAME}:v1.2.3"
+DIGEST = "sha256:" + "ab" * 32
+DIGEST_TAG = "sha256-" + "ab" * 32
+DIGEST_URI = f"{IMAGE_NAME}@{DIGEST}"
+
+ECR_DEPLOYMENT_RESOURCE = "Custom::CDKECRDeployment"
+
+requires_ecr_deployment = pytest.mark.skipif(
+    importlib.util.find_spec("cdk_ecr_deployment") is None,
+    reason="mirroring needs the optional `ecr-mirror` extra (cdk-ecr-deployment)",
+)
+
+
+def patched_digest(digest: str = DIGEST):
+    """Patch the digest resolver so that no test ever reaches a registry.
+
+    Args:
+        digest: The digest the resolver should return.
+
+    Returns:
+        A patcher whose mock records how the resolver was called.
+    """
+    return patch(
+        "aibs_informatics_cdk_lib.constructs_.assets.docker_asset.resolve_image_digest",
+        return_value=digest,
+    )
 
 
 class DockerAssetBaseTest(CdkBaseTest):
@@ -91,6 +121,34 @@ class TestDockerAssetConstruction(DockerAssetBaseTest):
         assert asset.source is None
         assert asset.image_uri == IMAGE_URI
 
+    def test__init__rejects_mirror_options_for_a_local_build(self):
+        """A built image is already in the CDK asset repository, which is ECR."""
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="apply to a `registry_image_uri`"):
+            DockerAsset(
+                stack,
+                "Image",
+                directory=self.build_context().as_posix(),
+                mirror_to_ecr=True,
+            )
+
+    def test__init__rejects_pin_digest_for_a_local_build(self):
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="apply to a `registry_image_uri`"):
+            DockerAsset(stack, "Image", directory=self.build_context().as_posix(), pin_digest=True)
+
+    def test__init__rejects_mirror_tags_without_mirroring(self):
+        """Silently ignoring a mirror option would leave the caller thinking it mirrored."""
+        stack = self.get_dummy_stack("test")
+        with pytest.raises(ValueError, match="unless `mirror_to_ecr=True`"):
+            DockerAsset(stack, "Image", registry_image_uri=IMAGE_URI, mirror_tags=["v1"])
+
+    def test__init__rejects_an_ecr_repository_without_mirroring(self):
+        stack = self.get_dummy_stack("test")
+        repository = ecr.Repository(stack, "Repo", repository_name="preexisting")
+        with pytest.raises(ValueError, match="unless `mirror_to_ecr=True`"):
+            DockerAsset(stack, "Image", registry_image_uri=IMAGE_URI, ecr_repository=repository)
+
 
 # ---------------------------------------------------------------------------
 # DockerAsset.from_source
@@ -134,6 +192,25 @@ class TestDockerAssetFromSource(DockerAssetBaseTest):
         with pytest.raises(ValueError, match="without a `directory`"):
             DockerAsset.from_source(stack, "Image", source)
 
+    def test__from_source__git_source_rejects_mirror_options(self):
+        stack = self.get_dummy_stack("test")
+        source = GitSource(url="git@github.com:org/repo.git", tag="v1.0.0")
+        with pytest.raises(ValueError, match="not available for GitSource"):
+            DockerAsset.from_source(
+                stack,
+                "Image",
+                source,
+                directory=self.build_context().as_posix(),
+                mirror_to_ecr=True,
+            )
+
+    def test__from_source__container_image_source_forwards_pin_digest(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(image=IMAGE_NAME, tag="v1.2.3")
+        with patched_digest():
+            asset = DockerAsset.from_source(stack, "Image", source, pin_digest=True)
+        assert asset.source_image_uri == DIGEST_URI
+
 
 # ---------------------------------------------------------------------------
 # URI accessors
@@ -160,6 +237,225 @@ class TestDockerAssetUris(DockerAssetBaseTest):
         stack = self.get_dummy_stack("test")
         asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
         assert asset.image_uri == asset.source_image_uri
+
+
+# ---------------------------------------------------------------------------
+# Digest Pinning in direct-pull mode
+# ---------------------------------------------------------------------------
+
+
+class TestDockerAssetDigestPinning(DockerAssetBaseTest):
+    def test__direct_pull__does_not_resolve_a_digest_by_default(self):
+        """Direct pull keeps following the mutable tag, and synth stays offline-capable."""
+        stack = self.get_dummy_stack("test")
+        with patched_digest() as mock_resolve:
+            asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        mock_resolve.assert_not_called()
+        assert asset.source_image_uri == IMAGE_URI
+
+    def test__pin_digest__references_the_image_by_its_resolved_digest(self):
+        stack = self.get_dummy_stack("test")
+        with patched_digest() as mock_resolve:
+            asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI, pin_digest=True)
+        mock_resolve.assert_called_once_with(IMAGE_NAME, "v1.2.3")
+        assert asset.source_image_uri == DIGEST_URI
+        assert asset.image_uri == DIGEST_URI
+
+    def test__pin_digest__does_not_put_the_image_in_ecr(self):
+        """Pinning names the image more precisely; it does not move it."""
+        stack = self.get_dummy_stack("test")
+        with patched_digest():
+            asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI, pin_digest=True)
+        assert asset.ecr_image_uri is None
+        assert asset.mirror_repository is None
+
+    def test__pin_digest__an_explicit_digest_skips_the_network(self):
+        stack = self.get_dummy_stack("test")
+        with patched_digest() as mock_resolve:
+            asset = DockerAsset.from_registry(stack, "Image", DIGEST_URI, pin_digest=True)
+        mock_resolve.assert_not_called()
+        assert asset.source_image_uri == DIGEST_URI
+
+    def test__pin_digest__untagged_reference_resolves_latest(self):
+        stack = self.get_dummy_stack("test")
+        with patched_digest() as mock_resolve:
+            DockerAsset.from_registry(stack, "Image", IMAGE_NAME, pin_digest=True)
+        mock_resolve.assert_called_once_with(IMAGE_NAME, "latest")
+
+    def test__pin_digest__resolution_failure_is_a_hard_error(self):
+        stack = self.get_dummy_stack("test")
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.docker_asset.resolve_image_digest",
+            side_effect=DigestResolutionError("boom"),
+        ):
+            with pytest.raises(DigestResolutionError):
+                DockerAsset.from_registry(stack, "Image", IMAGE_URI, pin_digest=True)
+
+
+# ---------------------------------------------------------------------------
+# Mirroring
+# ---------------------------------------------------------------------------
+
+
+@requires_ecr_deployment
+class TestDockerAssetMirroring(DockerAssetBaseTest):
+    def mirrored(self, image=IMAGE_URI, **kwargs) -> DockerAsset:
+        stack = kwargs.pop("stack", None) or self.get_dummy_stack("test")
+        with patched_digest():
+            return DockerAsset.from_registry(stack, "Image", image, mirror_to_ecr=True, **kwargs)
+
+    def test__mirror__creates_a_retained_repository_named_for_the_env_and_asset(self):
+        stack = self.get_dummy_stack("test")
+        self.mirrored(stack=stack)
+        template = self.get_template(stack)
+        template.resource_count_is("AWS::ECR::Repository", 1)
+        template.has_resource_properties(
+            "AWS::ECR::Repository",
+            {"RepositoryName": f"{self.env_base}-aibs-informatics-aws-lambda"},
+        )
+        template.has_resource("AWS::ECR::Repository", {"DeletionPolicy": "Retain"})
+
+    def test__mirror__deploys_one_ecr_deployment_per_destination_tag(self):
+        stack = self.get_dummy_stack("test")
+        self.mirrored(stack=stack)
+        self.get_template(stack).resource_count_is(ECR_DEPLOYMENT_RESOURCE, 2)
+
+    def test__mirror__defaults_to_a_digest_tag_plus_the_source_tag(self):
+        asset = self.mirrored()
+        assert asset.mirror_tags == (DIGEST_TAG, "v1.2.3")
+
+    def test__mirror__digest_tag_sanitizes_the_illegal_colon(self):
+        asset = self.mirrored()
+        assert ":" not in asset.mirror_tags[0]
+
+    def test__mirror__copies_from_the_digest_not_the_tag(self):
+        """A tag-to-tag copy would run once and then never notice the tag moving."""
+        stack = self.get_dummy_stack("test")
+        self.mirrored(stack=stack)
+        self.get_template(stack).has_resource_properties(
+            ECR_DEPLOYMENT_RESOURCE, {"SrcImage": f"docker://{DIGEST_URI}"}
+        )
+
+    def test__mirror__resolves_a_mutable_tag_at_synth(self):
+        stack = self.get_dummy_stack("test")
+        with patched_digest() as mock_resolve:
+            DockerAsset.from_registry(stack, "Image", IMAGE_URI, mirror_to_ecr=True)
+        mock_resolve.assert_called_once_with(IMAGE_NAME, "v1.2.3")
+
+    def test__mirror__an_explicit_digest_skips_the_network(self):
+        stack = self.get_dummy_stack("test")
+        with patched_digest() as mock_resolve:
+            asset = DockerAsset.from_registry(stack, "Image", DIGEST_URI, mirror_to_ecr=True)
+        mock_resolve.assert_not_called()
+        # No source tag to alias, so the digest tag is the only destination.
+        assert asset.mirror_tags == (DIGEST_TAG,)
+
+    def test__mirror__resolution_failure_raises_naming_the_fix(self):
+        stack = self.get_dummy_stack("test")
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.docker_asset.resolve_image_digest",
+            side_effect=DigestResolutionError("Pin the digest explicitly"),
+        ):
+            with pytest.raises(DigestResolutionError, match="Pin the digest explicitly"):
+                DockerAsset.from_registry(stack, "Image", IMAGE_URI, mirror_to_ecr=True)
+
+    def test__mirror__resolution_failure_never_falls_back_to_the_mutable_tag(self):
+        stack = self.get_dummy_stack("test")
+        with patch(
+            "aibs_informatics_cdk_lib.constructs_.assets.docker_asset.resolve_image_digest",
+            side_effect=DigestResolutionError("boom"),
+        ):
+            with pytest.raises(DigestResolutionError):
+                DockerAsset.from_registry(stack, "Image", IMAGE_URI, mirror_to_ecr=True)
+        self.get_template(stack).resource_count_is(ECR_DEPLOYMENT_RESOURCE, 0)
+
+    def test__mirror__mirror_tags_overrides_the_default_pair(self):
+        """The escape hatch when two deployments cost more than the alias is worth."""
+        stack = self.get_dummy_stack("test")
+        asset = self.mirrored(stack=stack, mirror_tags=["stable"])
+        assert asset.mirror_tags == ("stable",)
+        self.get_template(stack).resource_count_is(ECR_DEPLOYMENT_RESOURCE, 1)
+
+    def test__mirror__empty_mirror_tags_raises(self):
+        with pytest.raises(ValueError, match="at least one destination tag"):
+            self.mirrored(mirror_tags=[])
+
+    def test__mirror__uses_a_supplied_repository_instead_of_creating_one(self):
+        stack = self.get_dummy_stack("test")
+        repository = ecr.Repository(stack, "Existing", repository_name="already-mine")
+        asset = self.mirrored(stack=stack, ecr_repository=repository)
+        assert asset.mirror_repository is repository
+        template = self.get_template(stack)
+        template.resource_count_is("AWS::ECR::Repository", 1)
+        template.has_resource_properties(
+            "AWS::ECR::Repository", {"RepositoryName": "already-mine"}
+        )
+
+    def test__mirror__ecr_image_uri_points_at_the_immutable_tag(self):
+        asset = self.mirrored()
+        ecr_image_uri = asset.ecr_image_uri
+        assert ecr_image_uri is not None
+        assert ecr_image_uri.endswith(f":{DIGEST_TAG}")
+        assert "dkr.ecr" in ecr_image_uri
+
+    def test__mirror__image_uri_prefers_ecr_over_the_origin_registry(self):
+        asset = self.mirrored()
+        # jsii mints a fresh token on every property read, so compare shape, not identity.
+        assert "dkr.ecr" in asset.image_uri
+        assert asset.image_uri.endswith(f":{DIGEST_TAG}")
+        assert asset.source_image_uri == IMAGE_URI
+
+    def test__mirror__as_lambda_code_uses_the_mirror_repository(self):
+        """The whole point for Lambda: AWS requires the container image to be in ECR."""
+        asset = self.mirrored()
+        with patch.object(lambda_.DockerImageCode, "from_ecr") as mock_from_ecr:
+            result = asset.as_lambda_code()
+        (repository,), kwargs = mock_from_ecr.call_args
+        assert repository is asset.mirror_repository
+        assert kwargs == {"tag_or_digest": DIGEST_TAG}
+        assert result is mock_from_ecr.return_value
+
+    def test__mirror__as_lambda_code_returns_docker_image_code(self):
+        asset = self.mirrored()
+        assert isinstance(asset.as_lambda_code(), lambda_.DockerImageCode)
+
+    def test__mirror__as_ecs_image_grants_pull_on_the_repository(self):
+        """from_registry would produce the same URI but grant the role no ECR permission."""
+        asset = self.mirrored()
+        with patch.object(ecs.ContainerImage, "from_ecr_repository") as mock_from_ecr:
+            result = asset.as_ecs_image()
+        mock_from_ecr.assert_called_once_with(asset.mirror_repository, tag=DIGEST_TAG)
+        assert result is mock_from_ecr.return_value
+
+    def test__mirror__from_source_forwards_the_mirror_options(self):
+        stack = self.get_dummy_stack("test")
+        source = ContainerImageSource(image=IMAGE_NAME, tag="v1.2.3")
+        with patched_digest():
+            asset = DockerAsset.from_source(stack, "Image", source, mirror_to_ecr=True)
+        assert asset.mirror_repository is not None
+        self.get_template(stack).resource_count_is(ECR_DEPLOYMENT_RESOURCE, 2)
+
+
+class TestDockerAssetMirroringWithoutTheExtra(DockerAssetBaseTest):
+    """Installing without the `ecr-mirror` extra must break nothing but mirroring."""
+
+    def test__mirror__without_cdk_ecr_deployment_raises_naming_the_extra(self):
+        stack = self.get_dummy_stack("test")
+        with patch.dict(sys.modules, {"cdk_ecr_deployment": None}):
+            with patched_digest():
+                with pytest.raises(ImportError, match="ecr-mirror"):
+                    DockerAsset.from_registry(stack, "Image", IMAGE_URI, mirror_to_ecr=True)
+
+    def test__direct_pull__works_without_cdk_ecr_deployment(self):
+        stack = self.get_dummy_stack("test")
+        with patch.dict(sys.modules, {"cdk_ecr_deployment": None}):
+            asset = DockerAsset.from_registry(stack, "Image", IMAGE_URI)
+        assert asset.image_uri == IMAGE_URI
+
+    def test__local_build__works_without_cdk_ecr_deployment(self):
+        with patch.dict(sys.modules, {"cdk_ecr_deployment": None}):
+            asset = self.local_build_asset()
+        assert asset.docker_image_asset is not None
 
 
 # ---------------------------------------------------------------------------

--- a/test/aibs_informatics_cdk_lib/constructs_/assets/test_registry.py
+++ b/test/aibs_informatics_cdk_lib/constructs_/assets/test_registry.py
@@ -1,0 +1,244 @@
+"""Tests for synth-time Digest Pinning.
+
+Every test mocks ``urlopen``. Nothing here touches the network -- the point of pinning is
+that a mirror stays correct, not that a registry answers.
+"""
+
+import json
+import urllib.error
+import urllib.request
+from unittest.mock import patch
+
+import pytest
+from pytest import mark, param
+
+from aibs_informatics_cdk_lib.constructs_.assets.registry import (
+    DIGEST_HEADER,
+    MANIFEST_MEDIA_TYPES,
+    DigestResolutionError,
+    digest_to_tag,
+    parse_image_reference,
+    resolve_image_digest,
+)
+
+IMAGE_NAME = "ghcr.io/alleninstitute/aibs-informatics-aws-lambda"
+DIGEST = "sha256:" + "ab" * 32
+TOKEN_URL = (
+    "https://ghcr.io/token"
+    "?scope=repository:alleninstitute/aibs-informatics-aws-lambda:pull&service=ghcr.io"
+)
+MANIFEST_URL = "https://ghcr.io/v2/alleninstitute/aibs-informatics-aws-lambda/manifests/latest"
+
+
+class FakeResponse:
+    """The subset of an ``http.client.HTTPResponse`` the resolver uses."""
+
+    def __init__(self, body: bytes = b"", headers: dict[str, str] | None = None):
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool:
+        return False
+
+
+def registry_responses(
+    token_payload: dict | None = None,
+    manifest_headers: dict[str, str] | None = None,
+):
+    """Build a ``urlopen`` side effect answering the token and manifest requests.
+
+    Args:
+        token_payload: The JSON body the token endpoint returns.
+        manifest_headers: The headers the manifest endpoint returns.
+
+    Returns:
+        A callable suitable as a ``urlopen`` mock side effect, and the list it records
+        every request into.
+    """
+    requests: list[urllib.request.Request] = []
+
+    def urlopen(request: urllib.request.Request, **kwargs: object) -> FakeResponse:
+        requests.append(request)
+        if "/token" in request.full_url:
+            payload = token_payload if token_payload is not None else {"token": "t0ken"}
+            return FakeResponse(body=json.dumps(payload).encode("utf-8"))
+        headers = manifest_headers if manifest_headers is not None else {DIGEST_HEADER: DIGEST}
+        return FakeResponse(headers=headers)
+
+    return urlopen, requests
+
+
+# ---------------------------------------------------------------------------
+# parse_image_reference
+# ---------------------------------------------------------------------------
+
+
+class TestParseImageReference:
+    @mark.parametrize(
+        "image_uri, expected",
+        [
+            param("ghcr.io/org/repo:v1.2.3", ("ghcr.io/org/repo", "v1.2.3", None), id="tag"),
+            param("ghcr.io/org/repo", ("ghcr.io/org/repo", None, None), id="no-tag"),
+            param(
+                f"ghcr.io/org/repo@{DIGEST}",
+                ("ghcr.io/org/repo", None, DIGEST),
+                id="digest",
+            ),
+            param(
+                f"ghcr.io/org/repo:v1@{DIGEST}",
+                ("ghcr.io/org/repo", "v1", DIGEST),
+                id="tag-and-digest",
+            ),
+            param(
+                "registry.local:5000/org/repo:v1",
+                ("registry.local:5000/org/repo", "v1", None),
+                id="registry-port-and-tag",
+            ),
+            param(
+                "registry.local:5000/org/repo",
+                ("registry.local:5000/org/repo", None, None),
+                id="registry-port-is-not-a-tag",
+            ),
+        ],
+    )
+    def test__parse_image_reference__splits_name_tag_and_digest(self, image_uri, expected):
+        assert parse_image_reference(image_uri) == expected
+
+
+# ---------------------------------------------------------------------------
+# digest_to_tag
+# ---------------------------------------------------------------------------
+
+
+class TestDigestToTag:
+    def test__digest_to_tag__replaces_the_illegal_colon(self):
+        """`:` is illegal in an ECR tag, so the digest tag has to be sanitized."""
+        assert digest_to_tag(DIGEST) == "sha256-" + "ab" * 32
+
+    def test__digest_to_tag__leaves_a_sanitized_digest_alone(self):
+        assert digest_to_tag("sha256-abc") == "sha256-abc"
+
+
+# ---------------------------------------------------------------------------
+# resolve_image_digest
+# ---------------------------------------------------------------------------
+
+
+class TestResolveImageDigest:
+    def test__resolve_image_digest__returns_the_digest_header(self):
+        urlopen, _ = registry_responses()
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            assert resolve_image_digest(IMAGE_NAME, "latest") == DIGEST
+
+    def test__resolve_image_digest__requests_an_anonymous_pull_scoped_token(self):
+        urlopen, requests = registry_responses()
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            resolve_image_digest(IMAGE_NAME, "latest")
+        assert requests[0].full_url == TOKEN_URL
+
+    def test__resolve_image_digest__heads_the_manifest_with_the_bearer_token(self):
+        urlopen, requests = registry_responses()
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            resolve_image_digest(IMAGE_NAME, "latest")
+        manifest_request = requests[1]
+        assert manifest_request.full_url == MANIFEST_URL
+        assert manifest_request.get_method() == "HEAD"
+        assert manifest_request.get_header("Authorization") == "Bearer t0ken"
+
+    def test__resolve_image_digest__accepts_multi_platform_indexes(self):
+        """A multi-platform image must resolve to its index digest, not one platform's."""
+        urlopen, requests = registry_responses()
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            resolve_image_digest(IMAGE_NAME, "latest")
+        accept = requests[1].get_header("Accept")
+        assert accept is not None
+        for media_type in MANIFEST_MEDIA_TYPES:
+            assert media_type in accept
+
+    def test__resolve_image_digest__defaults_to_the_latest_tag(self):
+        urlopen, requests = registry_responses()
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            resolve_image_digest(IMAGE_NAME)
+        assert requests[1].full_url.endswith("/manifests/latest")
+
+    def test__resolve_image_digest__accepts_an_access_token_field(self):
+        urlopen, _ = registry_responses(token_payload={"access_token": "other"})
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            assert resolve_image_digest(IMAGE_NAME, "latest") == DIGEST
+
+    def test__resolve_image_digest__uses_a_supplied_auth_header(self):
+        """Auth is pluggable for a future private package; no token request is made."""
+        urlopen, requests = registry_responses()
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            resolve_image_digest(IMAGE_NAME, "latest", auth_header=lambda reg, repo: "Bearer mine")
+        assert len(requests) == 1
+        assert requests[0].get_header("Authorization") == "Bearer mine"
+
+    def test__resolve_image_digest__auth_header_provider_sees_registry_and_repository(self):
+        urlopen, _ = registry_responses()
+        seen: list[tuple[str, str]] = []
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            resolve_image_digest(
+                IMAGE_NAME,
+                "latest",
+                auth_header=lambda reg, repo: seen.append((reg, repo)) or None,  # type: ignore
+            )
+        assert seen == [("ghcr.io", "alleninstitute/aibs-informatics-aws-lambda")]
+
+    def test__resolve_image_digest__omits_authorization_when_the_provider_returns_none(self):
+        urlopen, requests = registry_responses()
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            resolve_image_digest(IMAGE_NAME, "latest", auth_header=lambda reg, repo: None)
+        assert requests[0].get_header("Authorization") is None
+
+
+class TestResolveImageDigestFailures:
+    """Resolution failure is a hard error naming the fix, never a fallback to the tag."""
+
+    def test__resolve_image_digest__unreachable_registry_raises(self):
+        with patch.object(urllib.request, "urlopen", side_effect=urllib.error.URLError("no dns")):
+            with pytest.raises(DigestResolutionError, match="Could not resolve"):
+                resolve_image_digest(IMAGE_NAME, "latest")
+
+    def test__resolve_image_digest__failure_names_the_explicit_digest_fix(self):
+        with patch.object(urllib.request, "urlopen", side_effect=urllib.error.URLError("no dns")):
+            with pytest.raises(DigestResolutionError, match=r"@sha256:<hex>"):
+                resolve_image_digest(IMAGE_NAME, "latest")
+
+    def test__resolve_image_digest__http_error_raises(self):
+        error = urllib.error.HTTPError(MANIFEST_URL, 404, "Not Found", {}, None)  # type: ignore
+        with patch.object(urllib.request, "urlopen", side_effect=error):
+            with pytest.raises(DigestResolutionError, match="HTTPError"):
+                resolve_image_digest(IMAGE_NAME, "latest")
+
+    def test__resolve_image_digest__unparseable_token_response_raises(self):
+        def urlopen(request, **kwargs):
+            return FakeResponse(body=b"<html>not json</html>")
+
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            with pytest.raises(DigestResolutionError, match="Could not resolve"):
+                resolve_image_digest(IMAGE_NAME, "latest")
+
+    def test__resolve_image_digest__token_denied_raises_naming_private_packages(self):
+        urlopen, _ = registry_responses(token_payload={"errors": ["denied"]})
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            with pytest.raises(DigestResolutionError, match="no anonymous pull token"):
+                resolve_image_digest(IMAGE_NAME, "latest")
+
+    def test__resolve_image_digest__missing_digest_header_raises(self):
+        urlopen, _ = registry_responses(manifest_headers={})
+        with patch.object(urllib.request, "urlopen", side_effect=urlopen):
+            with pytest.raises(DigestResolutionError, match=DIGEST_HEADER):
+                resolve_image_digest(IMAGE_NAME, "latest")
+
+    def test__resolve_image_digest__image_without_a_registry_host_raises(self):
+        with patch.object(urllib.request, "urlopen") as mock_urlopen:
+            with pytest.raises(DigestResolutionError, match="no registry host"):
+                resolve_image_digest("repo", "latest")
+        mock_urlopen.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -27,12 +27,18 @@ dependencies = [
     { name = "pydantic" },
 ]
 
+[package.optional-dependencies]
+ecr-mirror = [
+    { name = "cdk-ecr-deployment" },
+]
+
 [package.dev-dependencies]
 all = [
     { name = "aibs-informatics-test-resources" },
     { name = "boto3-stubs", extra = ["batch", "s3"] },
     { name = "build" },
     { name = "bump-my-version" },
+    { name = "cdk-ecr-deployment" },
     { name = "griffe-pydantic" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -44,6 +50,7 @@ all = [
 ]
 dev = [
     { name = "aibs-informatics-test-resources" },
+    { name = "cdk-ecr-deployment" },
 ]
 docs = [
     { name = "griffe-pydantic" },
@@ -68,9 +75,11 @@ requires-dist = [
     { name = "aibs-informatics-aws-utils", specifier = "~=1.0" },
     { name = "aibs-informatics-core", specifier = ">=1.0.1,<2" },
     { name = "aws-cdk-lib", specifier = "~=2.96" },
+    { name = "cdk-ecr-deployment", marker = "extra == 'ecr-mirror'", specifier = ">=3.1,<5" },
     { name = "constructs", specifier = "~=10.0" },
     { name = "pydantic", specifier = "~=2.0" },
 ]
+provides-extras = ["ecr-mirror"]
 
 [package.metadata.requires-dev]
 all = [
@@ -78,6 +87,7 @@ all = [
     { name = "boto3-stubs", extras = ["s3", "batch"] },
     { name = "build" },
     { name = "bump-my-version" },
+    { name = "cdk-ecr-deployment", specifier = ">=3.1,<5" },
     { name = "griffe-pydantic", specifier = "~=1.1" },
     { name = "mkdocs", specifier = "~=1.6" },
     { name = "mkdocs-material", specifier = "~=9.5" },
@@ -87,7 +97,10 @@ all = [
     { name = "types-pyyaml" },
     { name = "wheel" },
 ]
-dev = [{ name = "aibs-informatics-test-resources", extras = ["all"], specifier = "~=0.0.4" }]
+dev = [
+    { name = "aibs-informatics-test-resources", extras = ["all"], specifier = "~=0.0.4" },
+    { name = "cdk-ecr-deployment", specifier = ">=3.1,<5" },
+]
 docs = [
     { name = "griffe-pydantic", specifier = "~=1.1" },
     { name = "mkdocs", specifier = "~=1.6" },
@@ -393,6 +406,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/00/2432bb2d445b39b5407f0a90e01b9a271475eea7caf913d7a86bcb956385/cattrs-25.3.0.tar.gz", hash = "sha256:1ac88d9e5eda10436c4517e390a4142d88638fe682c436c93db7ce4a277b884a", size = 509321, upload-time = "2025-10-07T12:26:08.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/2b/a40e1488fdfa02d3f9a653a61a5935ea08b3c2225ee818db6a76c7ba9695/cattrs-25.3.0-py3-none-any.whl", hash = "sha256:9896e84e0a5bf723bc7b4b68f4481785367ce07a8a02e7e9ee6eb2819bc306ff", size = 70738, upload-time = "2025-10-07T12:26:06.603Z" },
+]
+
+[[package]]
+name = "cdk-ecr-deployment"
+version = "4.2.45"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-cdk-lib" },
+    { name = "constructs" },
+    { name = "jsii" },
+    { name = "publication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/9b/f83e95b1f4d1426cdc2b9d2d3f9c44f733260ef24d9a191ce702c988cb49/cdk_ecr_deployment-4.2.45.tar.gz", hash = "sha256:0dd1dafd88cdff6808d6407b2b1069d4d31b7971314675d63119efdf0fa5ba6f", size = 23293828, upload-time = "2026-08-05T07:42:08.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/da/5e6a747e4313f3076200932de5e5d8f0f43b518f244b96af62cfb88f96a2/cdk_ecr_deployment-4.2.45-py3-none-any.whl", hash = "sha256:ee5828688aaa4294ec31c9167512693f0e39ea1a69cd3e9a04bb90a16433aad8", size = 23292109, upload-time = "2026-08-05T07:42:05.47Z" },
 ]
 
 [[package]]
@@ -726,15 +754,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-resources"
-version = "6.5.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -775,20 +794,19 @@ wheels = [
 
 [[package]]
 name = "jsii"
-version = "1.127.0"
+version = "1.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "cattrs" },
-    { name = "importlib-resources" },
     { name = "publication" },
     { name = "python-dateutil" },
     { name = "typeguard" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/e8/a163295e70ecc652bfd7960c83f9a61ee4283f2ef73d6df23ac57b430f6c/jsii-1.127.0.tar.gz", hash = "sha256:631a13d73265eaa22c0c0804e77fe59c8fcc3af3a94de9923af65380b6ad267a", size = 461782, upload-time = "2026-02-25T16:54:04.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/71/7c612c16291a6dc654bac00f56bef24c45f86e9a7c9668dc7d36f187e808/jsii-1.139.0.tar.gz", hash = "sha256:163c5d3ec00fd4ec89a33b9097f20a6f27626dd69d6875a8f7cc7577b8021ad0", size = 531387, upload-time = "2026-07-17T02:34:33.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/91/3b58a04d06cb6abbb3806ca5fcf4b8933a85e013d24d983d3535d9fb6566/jsii-1.127.0-py3-none-any.whl", hash = "sha256:92a11f39e461f5168e2467efd53351cc32b118314b95cc6323c2d044eb299eaf", size = 436980, upload-time = "2026-02-25T16:54:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/33/3e/fce01768f79b2d5d0cf6258b55045f4b083ee86fd5de24c1af38168312ab/jsii-1.139.0-py3-none-any.whl", hash = "sha256:11468f767c6da698ed9888a04352850af33ccccfec7656475626caf36fca8bbb", size = 501693, upload-time = "2026-07-17T02:34:31.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Stack 3 of 3** — base is #62, review that first. [DT-9928](https://alleninstitute.atlassian.net/browse/DT-9928).

**This one is deferrable.** Direct GHCR pull (stack 2) already covers AWS Batch. Mirroring earns its keep only for in-region pull cost, independence from GitHub availability, or Lambda container images. Nothing in #57 or #62 needs it.

## Why, and why *not* throttling

Registry throttling is **not** the motivation — GHCR publishes no pull rate limit for public packages and public usage is free, unlike Docker Hub's 100-pulls-per-6h anonymous cap. The real cost of direct pull is NAT gateway data processing at ~$0.045/GB, paid on each fresh Batch instance (`ECS_IMAGE_PULL_BEHAVIOR=default` caches per instance, not per job). Full reasoning in `docs/adr/0002-…`.

## Changes

- **`registry.py`** — `resolve_image_digest()` over stdlib `urllib` only: anonymous OCI token, then `HEAD /v2/<name>/manifests/<tag>`, reading `Docker-Content-Digest`. Plus `parse_image_reference()`, `digest_to_tag()`, `DigestResolutionError`. The `auth_header` hook is pluggable so a token can be added for private packages later; no credential plumbing is built.
- **`DockerAsset(..., mirror_to_ecr, ecr_repository, mirror_tags, pin_digest)`** — creates `{env_base}-{asset_name}` with `RETAIN` unless a repository is supplied, then one `ECRDeployment` per tag. Fills in the `ecr_image_uri` seam from #62, which is what makes `image_uri` and `as_lambda_code()` correct for a mirrored asset.
- `as_ecs_image()` uses `from_ecr_repository` when mirrored, so the execution role is actually granted the pull — `from_registry` would produce the same URI with no permission.
- `cdk-ecr-deployment` as an **optional extra** (`ecr-mirror`, `>=3.1,<5`) with a lazy import.

## Two decisions worth your attention

**Mirroring forces digest resolution.** CloudFormation invokes a custom resource only when its properties change, so mirroring `:latest` → `:latest` would run once at first deploy and then freeze the ECR copy forever while `latest` moved on. Enabling a mirror therefore resolves the tag to its digest at synth. An explicit digest skips the network entirely, so synth stays offline-capable; resolution failure is a hard error naming that fix, never a silent fallback.

**The dependency is optional on purpose.** `gcs`, `ocs`, and `ocs-deploy` all pin `cdk-ecr-deployment~=3.1.13`, while upstream supports only v4. A hard dependency on either major makes those three unresolvable the moment they bump. An extra with a wide range lets each repo choose.

## Verification

`281 passed` (224 on #62), `ruff check`, `ruff format --check`, and `mypy` on the assets package all clean.

**Confirmed working without the extra:** with `cdk-ecr-deployment` uninstalled — `262 passed, 18 skipped, 0 failed`. All imports succeed, direct-pull `image_uri`/`resolve_image_uri`/`as_ecs_image()` work, and `mirror_to_ecr=True` raises an `ImportError` naming the extra.

[DT-9928]: https://alleninstitute.atlassian.net/browse/DT-9928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ